### PR TITLE
[DP&RS][DDCE-1770] Refactor to stream csv files from upscan

### DIFF
--- a/.GITHUB/PULL_REQUEST_TEMPLATE.md
+++ b/.GITHUB/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,7 @@
 # DDCE-StoryNumberHere
-
-## Bug fix / New feature (delete as appropriate)
-
 Please include a summary / description of the change and which issue it fixes.  Include any relevant user needs, context or links to other PRs related to this PR (eg. acceptance tests, environment config).
-
-## PR Suggestions
-- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
-- Have you done a visual check of the changes?
-- Is there any still commented or unused code? Lingering printlns?
-- Have things been implemented in a complicated way?
-- Are the test still over the coverage threshold?
-- Does the compiler throw a lot of warnings?
-- Have methods and tests been named clearly?
-- Were there any changes in the config? Do changes need to be made in app-config-???
-- Have you done a manual walkthrough?
-
-
-## Checklist PR Raiser
- - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
- - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
- - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
- - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
- - [ ]  I've run a dependency check to ensure all dependencies are up to date
-
-## Checklist PR Reviewer
- - [ ]  I've verified every effort was made to commit high quality, clean code and I have executed relevant static analyses to be sure
- - [ ]  I've verified appropriate tests were included with any code added (Unit, Integration, Acceptance etc.)
- - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
- - [ ]  I've verified commits were squashed and rebased - including the JIRA issue number in the commit message
- - [ ]  I've run a dependency check to ensure all dependencies are up to date
+- [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
+- [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
+- [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
+- [ ]  I've squashed my commits - including the JIRA issue number in the commit message
+- [ ]  I've run a dependency check to ensure all dependencies are up to date

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 
-# ers-submissions
+# ERS-Submissions
 
-[![Build Status](https://travis-ci.org/hmrc/ers-submissions.svg?branch=master)](https://travis-ci.org/hmrc/ers-submissions) [ ![Download](https://api.bintray.com/packages/hmrc/releases/ers-submissions/images/download.svg) ](https://bintray.com/hmrc/releases/ers-submissions/_latestVersion)
+[![Download](https://api.bintray.com/packages/hmrc/releases/ers-submissions/images/download.svg) ](https://bintray.com/hmrc/releases/ers-submissions/_latestVersion)
 
-This is a placeholder README.md for a new repository
+This microservice handles the submission of an ERS return to ADR.
+
+When ERS-Submissions receives a call from ERS-File-Validator, it stores the data from the validated file (split into chunks) into Mongo as a pre-submission.
+The user will then finish their journey on ERS-Returns-Frontend which will tell Submissions (via ERS-Returns) to submit the
+data to ADR for processing.
+
+For CSV files, ERS-Submissions uses Akka-streams to stream the file from upscan and store it into Mongo <br>
+For ODS files, ERS-Submissions receives the file body from ERS-File-Validator as Json which is then stored into Mongo
+
+For large files this service will not submit the file immediately, instead scheduling the submission to be at a later, less busy time.
 
 ### License
 

--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -27,6 +27,10 @@ class ApplicationConfig @Inject()(serviceConfig: ServicesConfig) {
 
   lazy val presubmissionCollection: String = serviceConfig.getString("settings.presubmission-collection")
   lazy val metadataCollection: String = serviceConfig.getString("settings.metadata-collection")
+  lazy val uploadCsvSizeLimit: Int = serviceConfig.getInt("csv.uploadSizeLimit")
+  lazy val maxGroupSize: Int = serviceConfig.getInt("csv.maxGroupSize")
+  //submissionParallelism refers to the number of threads used while submitting the file to the repository.
+  lazy val submissionParallelism: Int = serviceConfig.getInt("csv.submitParallelism")
 
   lazy val adrBaseURI: String = serviceConfig.baseUrl("ers-stub")
   lazy val adrFullSubmissionURI: String = serviceConfig.getString("microservice.services.ers-stub.full-submission-url")

--- a/app/models/SchemeData.scala
+++ b/app/models/SchemeData.scala
@@ -17,11 +17,8 @@
 package models
 import com.github.nscala_time.time.Imports.DateTimeZone
 import org.joda.time.DateTime
-import play.api.libs.functional.syntax.toFunctionalBuilderOps
-import play.api.libs.json.{Format, JsValue, Json, OFormat, Reads, Writes, __}
-import play.api.libs.json.JodaReads._
-import play.api.libs.json.JodaWrites._
-import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+import play.api.libs.json.{Format, Json, OFormat, Reads, Writes, __}
+
 
 import scala.collection.mutable.ListBuffer
 
@@ -41,9 +38,7 @@ object SchemeInfo {
       new DateTime(dateTime, DateTimeZone.UTC)
     }
 
-  private val dateTimeWrite: Writes[DateTime] = new Writes[DateTime] {
-    def writes(dateTime: DateTime): JsValue = Json.toJson(dateTime.getMillis)
-  }
+  private val dateTimeWrite: Writes[DateTime] = (dateTime: DateTime) => Json.toJson(dateTime.getMillis)
 
   implicit val dateTimeFormats: Format[DateTime] = Format(dateTimeRead, dateTimeWrite)
   implicit val format: OFormat[SchemeInfo] = Json.format[SchemeInfo]
@@ -58,6 +53,17 @@ case class SchemeData(
                        )
 object SchemeData {
   implicit val format: OFormat[SchemeData] = Json.format[SchemeData]
+}
+
+case class SubmissionsSchemeData(
+                       schemeInfo: SchemeInfo,
+                       sheetName: String,
+                       data: UpscanCallback,
+                       numberOfRows: Int
+                       )
+
+object SubmissionsSchemeData {
+  implicit val format: OFormat[SubmissionsSchemeData] = Json.format[SubmissionsSchemeData]
 }
 
 case class SchemeRefContainer(schemeRef: String)

--- a/app/models/UpscanCallback.scala
+++ b/app/models/UpscanCallback.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{JsObject, Json, Reads, Writes}
+
+case class UpscanCallback(name: String,
+                          downloadUrl: String,
+                          length: Option[Long] = None,
+                          contentType: Option[String] = None,
+                          customMetadata: Option[JsObject] = None,
+                          noOfRows: Option[Int] = None,
+                          _type: Option[String] = None
+                         )
+
+object UpscanCallback {
+  implicit val upscanCallbackWrites: Writes[UpscanCallback] = Json.writes[UpscanCallback]
+
+  implicit val upscanCallbackReads: Reads[UpscanCallback] = Json.reads[UpscanCallback]
+}

--- a/app/repositories/DataVerificationRepository.scala
+++ b/app/repositories/DataVerificationRepository.scala
@@ -22,7 +22,7 @@ import models.{ERSDataResults, ERSQuery, SchemeData}
 import org.joda.time.DateTime
 import play.api.libs.json.JsObject
 import play.modules.reactivemongo.ReactiveMongoComponent
-import reactivemongo.api.{Cursor, DB}
+import reactivemongo.api.Cursor
 import reactivemongo.bson._
 import reactivemongo.play.json.ImplicitBSONHandlers._
 import uk.gov.hmrc.mongo.ReactiveRepository

--- a/app/repositories/MetaDataVerificationRepository.scala
+++ b/app/repositories/MetaDataVerificationRepository.scala
@@ -20,9 +20,8 @@ import config.ApplicationConfig
 import javax.inject.Inject
 import models.{ERSMetaDataResults, ERSQuery, ErsSummary}
 import org.joda.time.DateTime
-import play.api.libs.json.JsObject
 import play.modules.reactivemongo.ReactiveMongoComponent
-import reactivemongo.api.{Cursor, DB}
+import reactivemongo.api.Cursor
 import reactivemongo.bson._
 import reactivemongo.play.json.ImplicitBSONHandlers._
 import uk.gov.hmrc.mongo.ReactiveRepository

--- a/app/repositories/MetadataMongoRepository.scala
+++ b/app/repositories/MetadataMongoRepository.scala
@@ -22,7 +22,7 @@ import models._
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.Format.GenericFormat
-import play.api.libs.json.{JsObject, JsString, JsValue, Json}
+import play.api.libs.json.Json
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.Cursor
 import reactivemongo.api.commands.WriteResult.Message

--- a/app/repositories/PresubmissionMongoRepository.scala
+++ b/app/repositories/PresubmissionMongoRepository.scala
@@ -14,37 +14,21 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package repositories
 
 import config.ApplicationConfig
-import javax.inject.Inject
 import models.{SchemeData, SchemeInfo}
 import play.api.Logger
-import play.api.libs.json.JsObject
+import play.api.libs.json.{JsObject, Json}
 import play.modules.reactivemongo.ReactiveMongoComponent
-import reactivemongo.api.{Cursor, DB}
+import reactivemongo.api.Cursor
 import reactivemongo.api.commands.WriteResult.Message
 import reactivemongo.api.indexes.{Index, IndexType}
 import reactivemongo.bson._
 import reactivemongo.play.json.ImplicitBSONHandlers._
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+import javax.inject.Inject
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -83,9 +67,26 @@ class PresubmissionMongoRepository @Inject()(applicationConfig: ApplicationConfi
   def storeJson(presubmissionData: SchemeData): Future[Boolean] = {
     collection.insert(presubmissionData).map { res =>
       if(res.writeErrors.nonEmpty) {
-        Logger.error(s"Faling storing presubmission data. Error: ${Message.unapply(res).getOrElse("")} for schemeInfo: ${presubmissionData.schemeInfo.toString}")
+        Logger.error(s"[PresubmissionMongoRepository][storeJson] Failed storing presubmission data. Error: " +
+          s"${Message.unapply(res).getOrElse("")} for schemeInfo:" +
+          s" ${presubmissionData.schemeInfo.toString}"
+        )
       }
       res.ok
+    }
+  }
+
+  def storeJsonV2(schemeInfo: String, presubmissionData: JsObject): Future[Boolean] = {
+    collection.insert(ordered = false).one(presubmissionData).map { res =>
+      if(res.writeErrors.nonEmpty) {
+        Logger.error(s"[PresubmissionMongoRepository][storeJsonV2] Failed storing presubmission data. Error: " +
+          s"${Message.unapply(res).getOrElse("")} for schemeInfo: ${schemeInfo}")
+      }
+      res.ok
+    }.recover {
+      case e: Throwable =>
+        Logger.error(s"Failed storing presubmission data. Error: ${e.getMessage} for schemeInfo: ${schemeInfo}")
+        throw e
     }
   }
 
@@ -111,22 +112,6 @@ class PresubmissionMongoRepository @Inject()(applicationConfig: ApplicationConfi
         Logger.error(s"Deleting presubmission error message: ${Message.unapply(res).getOrElse("")} for schemeInfo: ${schemeInfo.toString}")
       }
       res.ok
-    }
-  }
-
-  def findAndUpdate(schemeInfo: SchemeInfo): Future[Option[SchemeData]] = {
-
-    val selector: BSONDocument = buildSelector(schemeInfo) ++ ("processed" -> BSONDocument("$exists" -> false))
-
-    val modifier: BSONDocument = BSONDocument(
-      "$set" -> BSONDocument("processed" -> true)
-    )
-
-    collection.findAndUpdate(selector, modifier).map { result =>
-      if(result.lastError.isDefined && result.lastError.get.err.isDefined) {
-        Logger.error(s"Error getting presubmission record: ${result.lastError.get.err.toString}")
-      }
-      result.result[SchemeData]
     }
   }
 

--- a/app/repositories/Repositories.scala
+++ b/app/repositories/Repositories.scala
@@ -18,8 +18,7 @@ package repositories
 
 import config.ApplicationConfig
 import javax.inject.Inject
-import uk.gov.hmrc.mongo.MongoConnector
-import play.modules.reactivemongo.{MongoDbConnection, ReactiveMongoComponent}
+import play.modules.reactivemongo.ReactiveMongoComponent
 import uk.gov.hmrc.lock.LockRepository
 
 

--- a/app/services/FileDownloadService.scala
+++ b/app/services/FileDownloadService.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.alpakka.csv.scaladsl.CsvParsing
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import config.ApplicationConfig
+import models.SubmissionsSchemeData
+import play.api.Logger
+import play.api.http.Status
+import uk.gov.hmrc.http.UpstreamErrorResponse
+
+import javax.inject.Inject
+import scala.concurrent.Future
+
+class FileDownloadService @Inject()(
+                                   appConfig: ApplicationConfig
+                                   )(implicit actorSystem: ActorSystem) {
+
+  def extractEntityData(response: HttpResponse): Source[ByteString, _] = {
+    val uploadCsvSizeLimit = appConfig.uploadCsvSizeLimit
+    response match {
+      case HttpResponse(akka.http.scaladsl.model.StatusCodes.OK, _, entity, _) => entity.withSizeLimit(uploadCsvSizeLimit).dataBytes
+      case notOkResponse =>
+        Logger.error(
+          s"[ProcessCsvService][extractEntityData] Illegal response from Upscan: ${notOkResponse.status.intValue}, " +
+            s"body: ${notOkResponse.entity.dataBytes}")
+        Source.failed(UpstreamErrorResponse("Could not download file from upscan", Status.INTERNAL_SERVER_ERROR))
+    }
+  }
+
+  def extractBodyOfRequest: Source[HttpResponse, _] => Source[List[ByteString], _] =
+    _.flatMapConcat(extractEntityData)
+      .via(CsvParsing.lineScanner())
+
+  def schemeDataToChunksWithIndex(schemeData: SubmissionsSchemeData, maxGroupSize: Int = appConfig.maxGroupSize): Source[(Seq[Seq[ByteString]], Long), _] = {
+    extractBodyOfRequest(streamFile(schemeData.data.downloadUrl))
+      .grouped(maxGroupSize)
+      .zipWithIndex
+  }
+
+  private[services] def streamFile(downloadUrl: String): Source[HttpResponse, _] = {
+    Source
+      .single(HttpRequest(uri = downloadUrl))
+      .mapAsync(parallelism = 1)(makeRequest)
+  }
+
+  private[services] def makeRequest(request: HttpRequest): Future[HttpResponse] = Http()(actorSystem).singleRequest(request)
+
+}

--- a/app/services/MetadataService.scala
+++ b/app/services/MetadataService.scala
@@ -21,7 +21,6 @@ import models.ErsSummary
 import play.api.Logger
 import play.api.libs.json.{JsError, JsObject, JsSuccess}
 import play.api.mvc.Request
-import repositories.Repositories
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.LoggingAndRexceptions.ErsLoggingAndAuditing
 import repositories.MetadataMongoRepository

--- a/app/services/PresubmissionService.scala
+++ b/app/services/PresubmissionService.scala
@@ -17,8 +17,9 @@
 package services
 
 import javax.inject.Inject
-import models.{SchemeData, SchemeInfo}
+import models.{SchemeData, SchemeInfo, SubmissionsSchemeData}
 import play.api.Logger
+import play.api.libs.json.JsObject
 import play.api.mvc.Request
 import repositories.{PresubmissionMongoRepository, Repositories}
 import utils.LoggingAndRexceptions.ErsLoggingAndAuditing
@@ -34,10 +35,19 @@ class PresubmissionService @Inject()(repositories: Repositories, ersLoggingAndAu
   def storeJson(presubmissionData: SchemeData)(implicit request: Request[_], hc: HeaderCarrier): Future[Boolean] = {
 
     presubmissionRepository.storeJson(presubmissionData).recover {
-      case ex: Exception => {
+      case ex: Exception =>
         ersLoggingAndAuditing.handleException(presubmissionData.schemeInfo, ex, "Exception during storing presubmission data")
         false
-      }
+    }
+
+  }
+
+  def storeJsonV2(presubmissionData: SubmissionsSchemeData, jsObject: JsObject)(implicit request: Request[_], hc: HeaderCarrier): Future[Boolean] = {
+
+    presubmissionRepository.storeJsonV2(presubmissionData.schemeInfo.toString, jsObject).recover {
+      case ex: Exception =>
+        ersLoggingAndAuditing.handleException(presubmissionData.schemeInfo, ex, "Exception during storing presubmission data in submission v2")
+        false
     }
 
   }
@@ -67,10 +77,6 @@ class PresubmissionService @Inject()(repositories: Repositories, ersLoggingAndAu
       }
     }
 
-  }
-
-  def findAndUpdate(schemeInfo: SchemeInfo)(implicit request: Request[_], hc: HeaderCarrier): Future[Option[SchemeData]] = {
-    presubmissionRepository.findAndUpdate(schemeInfo)
   }
 
 }

--- a/app/services/ValidationService.scala
+++ b/app/services/ValidationService.scala
@@ -17,7 +17,7 @@
 package services
 
 import javax.inject.Inject
-import models.{SchemeData, SchemeInfo}
+import models.{SchemeData, SchemeInfo, SubmissionsSchemeData}
 import play.api.libs.json.{JsError, JsObject, JsSuccess}
 
 class ValidationService @Inject()() {
@@ -25,18 +25,23 @@ class ValidationService @Inject()() {
   def validateSchemeData(json: JsObject): Option[SchemeData] = {
     json.validate[SchemeData] match {
       case schemeData: JsSuccess[SchemeData] => Some(schemeData.value)
-      case e: JsError => {
+      case _: JsError => {
         None
       }
+    }
+  }
+
+  def validateSubmissionsSchemeData(json: JsObject): Option[SubmissionsSchemeData] = {
+    json.validate[SubmissionsSchemeData] match {
+      case schemeData: JsSuccess[SubmissionsSchemeData] => Some(schemeData.value)
+      case _: JsError => None
     }
   }
 
   def validateSchemeInfo(json: JsObject): Option[SchemeInfo] = {
     json.validate[SchemeInfo] match {
       case schemeInfo: JsSuccess[SchemeInfo] => Some(schemeInfo.value)
-      case e: JsError => {
-        None
-      }
+      case _: JsError => None
     }
   }
 

--- a/app/utils/ADRSubmission.scala
+++ b/app/utils/ADRSubmission.scala
@@ -27,7 +27,6 @@ import utils.LoggingAndRexceptions.ADRExceptionEmitter
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.concurrent.Future
-import util.control.Breaks._
 import scala.concurrent.ExecutionContext.Implicits.global
 import uk.gov.hmrc.http.HeaderCarrier
 

--- a/app/utils/LoggingAndRexceptions/ErsLogger.scala
+++ b/app/utils/LoggingAndRexceptions/ErsLogger.scala
@@ -43,22 +43,4 @@ trait ErsLogger extends ErsDataMessages with ErsExceptionMessages {
     Logger.warn(buildMessage(message, data))
   }
 
-  def logSliced(data: List[String], lengthMessage: String, dataMessage: String): Unit = {
-    val maxNumber: Int = 20
-
-    def numberOfSlices(listLength: Int): Int = {
-      if(listLength%maxNumber > 0)
-        listLength/maxNumber + 1
-      else
-        listLength/maxNumber
-    }
-
-    val listLength = data.length
-    logWarn(s"${listLength} ${lengthMessage}")
-    val slices: Int = numberOfSlices(listLength)
-    for (i <- 0 until slices * maxNumber by maxNumber) {
-      logWarn(s"${dataMessage}:\n${data.slice(i, (i + maxNumber))}")
-    }
-  }
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -40,9 +40,6 @@ lazy val scoverageSettings = {
   )
 }
 
-val akkaVersion = "2.5.23"
-val akkaHttpVersion = "10.0.15"
-
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(plugins : _*)
   .settings(scoverageSettings : _*)
@@ -53,11 +50,6 @@ lazy val microservice = Project(appName, file("."))
     targetJvm := "jvm-1.8",
     scalaVersion := "2.12.12",
     libraryDependencies ++= appDependencies,
-    dependencyOverrides += "com.typesafe.akka" %% "akka-stream"    % akkaVersion,
-    dependencyOverrides += "com.typesafe.akka" %% "akka-protobuf"  % akkaVersion,
-    dependencyOverrides += "com.typesafe.akka" %% "akka-slf4j"     % akkaVersion,
-    dependencyOverrides += "com.typesafe.akka" %% "akka-actor"     % akkaVersion,
-    dependencyOverrides += "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion,
     parallelExecution in Test := false,
     fork in Test := false,
     retrieveManaged := true,
@@ -79,4 +71,9 @@ lazy val microservice = Project(appName, file("."))
   )
   .settings(majorVersion := 1)
   .settings(resolvers += Resolver.jcenterRepo)
+  .settings(PlayKeys.playDefaultPort := 9292)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
+
+scalacOptions ++= Seq(
+  "-P:silencer:pathFilters=views;routes"
+)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,8 +1,12 @@
 # microservice specific routes
 
-GET         /assets/*file                                       @controllers.Assets.at(path="/public", file)
+GET         /assets/*file                                        @controllers.Assets.at(path="/public", file)
 
+# Used by ods files
 POST        /:empRef/submit-presubmission                       @controllers.ReceivePresubmissionController.receivePresubmissionJson(empRef: String)
+
+# Used by csv files
+POST        /v2/:empRef/submit-presubmission                    @controllers.ReceivePresubmissionController.receivePresubmissionJsonV2(empRef: String)
 
 POST        /submit-metadata                                    @controllers.SubmissionController.receiveMetadataJson
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -245,3 +245,8 @@ mongo-async-driver.akka {
   log-dead-letters-during-shutdown = off
 }
 
+csv {
+  uploadSizeLimit = 104857600
+  maxGroupSize = 10000
+  submitParallelism = 2
+}

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -47,7 +47,11 @@
 
     <logger name="org.asynchttpclient.netty.channel" level="WARN"/>
 
+    <logger name="play.shaded.ahc.org.asynchttpclient.netty.channel.DefaultChannelPool" level="WARN"/>
+
     <logger name="com.google.inject" level="INFO"/>
+
+    <logger name="WARN" level="INFO"/>
 
     <logger name="application" level="INFO"/>
 

--- a/it/uk/gov/hmrc/Fixtures.scala
+++ b/it/uk/gov/hmrc/Fixtures.scala
@@ -18,14 +18,14 @@ package uk.gov.hmrc
 
 import _root_.play.api.libs.json.{JsValue, Json, JsObject}
 import models._
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 
 import scala.collection.mutable.ListBuffer
 
 object Fixtures {
   val invalidPayload: JsObject = Json.obj("invalid data" -> "test")
 
-  val timestamp: DateTime = DateTime.now
+  val timestamp: DateTime = DateTime.now(DateTimeZone.UTC)
 
   val schemeInfo: SchemeInfo = SchemeInfo (
     schemeRef = "XA1100000000000",
@@ -36,6 +36,14 @@ object Fixtures {
     schemeType = "EMI"
   )
   val schemeInfoPayload: JsValue = Json.toJson(schemeInfo)
+
+  val submissionsSchemeData: SubmissionsSchemeData = SubmissionsSchemeData(
+    schemeInfo,
+    "EMI40_Adjustments_V3",
+    UpscanCallback("EMI40_Adjustments_V3", "downloadUrl"),
+    1
+  )
+  val submissionsSchemeDataJson: JsObject = Json.toJson(submissionsSchemeData).as[JsObject]
 
   val ersMetaData = ErsMetaData(
     schemeInfo = schemeInfo,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,23 +4,28 @@ object AppDependencies {
   import play.core.PlayVersion
   import play.sbt.PlayImport._
 
-  private val hmrcTestVersion = "3.8.0-play-26"
-  private val domainVersion = "5.9.0-play-26"
-  private val reactiveMongoTestVersion = "4.21.0-play-26"
-  private val scalatestVersion = "3.0.9"
-  private val pegdownVersion = "1.6.0"
-  private val jsoupVersion = "1.13.1"
+  private val silencerVersion = "1.7.1"
+  private val akkaVersion = "2.6.12"
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-26" % "3.0.0",
-    "uk.gov.hmrc"       %% "domain"                    % domainVersion,
-    "uk.gov.hmrc"       %% "auth-client"               % "3.2.0-play-26",
-    "uk.gov.hmrc"       %% "mongo-lock"                % "6.23.0-play-26",
-    "uk.gov.hmrc"       %% "simple-reactivemongo"      % "7.30.0-play-26",
-    "com.typesafe.play" %% "play-json-joda"            % "2.7.4",
-    "xerces"             % "xercesImpl"                % "2.12.0",
-    "io.netty"                % "netty-transport-native-epoll"    % "4.0.17.Final"
+    "uk.gov.hmrc"        %% "bootstrap-backend-play-26"           % "3.0.0",
+    "uk.gov.hmrc"        %% "domain"                              % "5.9.0-play-26",
+    "uk.gov.hmrc"        %% "auth-client"                         % "3.2.0-play-26",
+    "uk.gov.hmrc"        %% "mongo-lock"                          % "6.23.0-play-26",
+    "uk.gov.hmrc"        %% "simple-reactivemongo"                % "7.30.0-play-26",
+    "org.reactivemongo"  %% "reactivemongo-akkastream"            % "0.20.13",
+    "com.typesafe.play"  %% "play-json-joda"                      % "2.7.4",
+    "xerces"             %  "xercesImpl"                          % "2.12.0",
+    "io.netty"           %  "netty-transport-native-epoll"        % "4.0.17.Final",
+    "com.lightbend.akka" %% "akka-stream-alpakka-csv"             % "2.0.2",
+    "com.lightbend.akka" %% "akka-stream-alpakka-json-streaming"  % "2.0.2",
+    "com.typesafe.akka"  %% "akka-stream"                         % akkaVersion,
+    "com.typesafe.akka"  %% "akka-slf4j"                          % akkaVersion,
+    "com.typesafe.akka"  %% "akka-protobuf"                       % akkaVersion,
+    "com.typesafe.akka"  %% "akka-http-spray-json"                % "10.1.12",
+    compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
+    "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
   )
 
   trait TestDependencies {
@@ -28,18 +33,27 @@ object AppDependencies {
     lazy val test : Seq[ModuleID] = Seq()
   }
 
+  private val mongoLockVersion = "6.23.0-play-26"
+  private val hmrcTestVersion = "3.8.0-play-26"
+  private val reactiveMongoTestVersion = "4.21.0-play-26"
+  private val pegdownVersion = "1.6.0"
+  private val jsoupVersion = "1.13.1"
+  private val scalaTestPlusPlayVersion = "3.1.3"
+  private val mockitoCoreVersion = "3.3.3"
+
   object Test {
     def apply(): Seq[ModuleID] = new TestDependencies {
       override lazy val test = Seq(
         "uk.gov.hmrc"            %% "reactivemongo-test" % reactiveMongoTestVersion % scope,
-        "org.scalatest"          %% "scalatest"          % scalatestVersion         % scope,
-        "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3"                  % scope,
-        "org.mockito"             % "mockito-core"       % "3.3.3"                  % scope,
-        "org.pegdown"             % "pegdown"            % pegdownVersion           % scope,
-        "org.jsoup"               % "jsoup"              % jsoupVersion             % scope,
+        "org.scalatest"          %% "scalatest"          % "3.0.9"                  % scope,
+        "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestPlusPlayVersion % scope,
+        "org.mockito"            %  "mockito-core"       % mockitoCoreVersion       % scope,
+        "org.pegdown"            %  "pegdown"            % pegdownVersion           % scope,
+        "org.jsoup"              %  "jsoup"              % jsoupVersion             % scope,
         "com.typesafe.play"      %% "play-test"          % PlayVersion.current      % scope,
         "uk.gov.hmrc"            %% "hmrctest"           % hmrcTestVersion          % scope,
-        "uk.gov.hmrc"            %% "mongo-lock"         % "6.23.0-play-26"
+        "uk.gov.hmrc"            %% "mongo-lock"         % mongoLockVersion         % scope,
+        "com.typesafe.akka"      %% "akka-testkit"       % akkaVersion              % scope
       )
     }.test
   }
@@ -50,16 +64,16 @@ object AppDependencies {
       override lazy val scope: String = "it"
 
       override lazy val test = Seq(
-        "uk.gov.hmrc"            %% "reactivemongo-test" % reactiveMongoTestVersion % scope,
-        "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3"                  % scope,
-        "org.pegdown"             % "pegdown"            % pegdownVersion           % scope,
-        "org.jsoup"               % "jsoup"              % jsoupVersion             % scope,
-        "org.mockito"             % "mockito-core"       % "2.6.9"                  % scope,
-        "com.typesafe.play"      %% "play-test"          % PlayVersion.current      % scope,
-        "io.netty"                % "netty-transport-native-epoll"    % "4.0.17.Final" % scope,
-        "uk.gov.hmrc"            %% "hmrctest"           % hmrcTestVersion          % scope,
-        "com.github.tomakehurst"  % "wiremock-jre8"      % "2.27.2"                 % scope,
-        "uk.gov.hmrc"            %% "mongo-lock"         % "6.23.0-play-26"         % scope
+        "uk.gov.hmrc"            %% "reactivemongo-test"           % reactiveMongoTestVersion % scope,
+        "org.scalatestplus.play" %% "scalatestplus-play"           % scalaTestPlusPlayVersion % scope,
+        "org.mockito"            %  "mockito-core"                 % mockitoCoreVersion       % scope,
+        "org.pegdown"            %  "pegdown"                      % pegdownVersion           % scope,
+        "org.jsoup"              %  "jsoup"                        % jsoupVersion             % scope,
+        "com.typesafe.play"      %% "play-test"                    % PlayVersion.current      % scope,
+        "uk.gov.hmrc"            %% "hmrctest"                     % hmrcTestVersion          % scope,
+        "uk.gov.hmrc"            %% "mongo-lock"                   % mongoLockVersion         % scope,
+        "io.netty"               %  "netty-transport-native-epoll" % "4.0.17.Final"           % scope,
+        "com.github.tomakehurst" %  "wiremock-jre8"                % "2.27.2"                 % scope
       )
     }.test
   }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -8,21 +8,21 @@
     </check>
     <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
         <parameters>
-            <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
-// See the LICENCE.txt file distributed with this work for additional
-// information regarding copyright ownership.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.]]></parameter>
+            <parameter name="header"><![CDATA[/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>

--- a/test/connectors/ADRConnectorSpec.scala
+++ b/test/connectors/ADRConnectorSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import fixtures.Fixtures
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.JsObject
 import play.api.test.Helpers._

--- a/test/controllers/PresubmissionControllerSpec.scala
+++ b/test/controllers/PresubmissionControllerSpec.scala
@@ -27,9 +27,9 @@ import org.scalatest.BeforeAndAfterEach
 import play.api.libs.json.{JsObject, Json}
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import services.{PresubmissionService, ValidationService}
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 import fixtures.Fixtures
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import utils.LoggingAndRexceptions.ErsLoggingAndAuditing

--- a/test/controllers/ReceivePresubmissionControllerSpec.scala
+++ b/test/controllers/ReceivePresubmissionControllerSpec.scala
@@ -16,31 +16,39 @@
 
 package controllers
 
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.scaladsl.Source
+import akka.testkit.TestKit
+import akka.util.ByteString
+import config.ApplicationConfig
 import controllers.auth.AuthAction
-import fixtures.{Fixtures, WithMockedAuthActions}
+import fixtures.{Fixtures, SIP, WithMockedAuthActions}
 import metrics.Metrics
-import models.SchemeData
+import models.{SchemeData, SubmissionsSchemeData, UpscanCallback}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import org.mockito.internal.verification.VerificationModeFactory
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.Status
 import play.api.libs.json.JsObject
 import play.api.mvc.{ControllerComponents, PlayBodyParsers, Request}
 import play.api.test.FakeRequest
 import services.audit.AuditEvents
-import services.{PresubmissionService, ValidationService}
+import services.{FileDownloadService, PresubmissionService, ValidationService}
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 import utils.LoggingAndRexceptions.ErsLoggingAndAuditing
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 
-class ReceivePresubmissionControllerSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEach with GuiceOneAppPerSuite with WithMockedAuthActions{
+class ReceivePresubmissionControllerSpec extends TestKit(ActorSystem("ReceivePresubmissionControllerSpec"))
+  with UnitSpec with MockitoSugar with BeforeAndAfterEach with GuiceOneAppPerSuite with WithMockedAuthActions {
 
   val mockAuthAction: AuthAction = mock[AuthAction]
   val mockPresubmissionService: PresubmissionService = mock[PresubmissionService]
@@ -50,9 +58,18 @@ class ReceivePresubmissionControllerSpec extends UnitSpec with MockitoSugar with
   val mockAuditEvents: AuditEvents = mock[AuditEvents]
   val mockCc: ControllerComponents = stubControllerComponents()
   val mockBodyParser: PlayBodyParsers = mock[PlayBodyParsers]
+  val mockApplicationConfig: ApplicationConfig = mock[ApplicationConfig]
+
+  def testFileDownloadService(downloadResponse: String): FileDownloadService = new FileDownloadService(mockApplicationConfig) {
+    override def makeRequest(request: HttpRequest): Future[HttpResponse] = Future.successful(HttpResponse(entity = downloadResponse))
+
+    when(mockApplicationConfig.uploadCsvSizeLimit).thenReturn(104857600)
+    when(mockApplicationConfig.maxGroupSize).thenReturn(10000)
+  }
 
   val mockMetrics: Metrics = mock[Metrics]
-  override def beforeEach() = {
+
+  override def beforeEach(): Unit = {
     super.beforeEach()
     reset(mockMetrics)
     reset(mockErsLoggingAndAuditing)
@@ -62,32 +79,55 @@ class ReceivePresubmissionControllerSpec extends UnitSpec with MockitoSugar with
     reset(mockAuditEvents)
   }
 
-  "calling receivePresubmissionJson" should {
+  def buildPresubmissionController(validationResult: Boolean = true,
+                                   storeJsonResult: Boolean = true,
+                                   downloadResponse: String = Fixtures.submissionsSchemeData.toString,
+                                   mockSubmissionResult: Boolean = false,
+                                   failSubmitJson: Option[Throwable] = None
+                                  ): ReceivePresubmissionController =
+    new ReceivePresubmissionController(
+      mockPresubmissionService,
+      mockValidationService,
+      testFileDownloadService(downloadResponse),
+      mockErsLoggingAndAuditing,
+      mockAuthConnector,
+      mockAuditEvents,
+      mockMetrics,
+      mockCc,
+      mockBodyParser,
+      mockApplicationConfig
+    ) {
+      mockJsValueAuthAction
 
-    def buildPresubmissionController(validationResult: Boolean = true, storeJsonResult: Boolean = true): ReceivePresubmissionController =
-      new ReceivePresubmissionController(
-        mockPresubmissionService,
-        mockValidationService,
-        mockErsLoggingAndAuditing,
-        mockAuthConnector,
-        mockAuditEvents,
-        mockMetrics,
-        mockCc,
-        mockBodyParser
-      ) {
-        mockJsValueAuthAction
-
+      when(mockApplicationConfig.submissionParallelism).thenReturn(2)
       when(mockPresubmissionService.storeJson(any[SchemeData])(any[Request[_]](), any[HeaderCarrier]()))
+        .thenReturn(Future(storeJsonResult))
+      when(mockPresubmissionService.storeJsonV2(any[SubmissionsSchemeData], any[JsObject])(any[Request[_]](), any[HeaderCarrier]()))
         .thenReturn(Future(storeJsonResult))
       when(mockValidationService.validateSchemeData(any[JsObject]))
         .thenReturn(if (validationResult) Some(Fixtures.schemeData) else None)
+      when(mockValidationService.validateSubmissionsSchemeData(any[JsObject]))
+        .thenReturn(if (validationResult) Some(Fixtures.submissionsSchemeData) else None)
 
       override def authorisedAction(empRef: String): AuthAction = mockAuthAction
+
+      override def submitJson(fileSource: Source[(Seq[Seq[ByteString]], Long), _], submissionsSchemeData: SubmissionsSchemeData)
+                             (implicit request: Request[_], hc: HeaderCarrier): Future[(Boolean, Long)] = {
+        if (mockSubmissionResult) {
+          Future((false, 3L))
+        } else if (failSubmitJson.isDefined) {
+          Future.failed(failSubmitJson.get)
+        } else {
+          super.submitJson(fileSource, submissionsSchemeData)
+        }
+      }
     }
+
+  "calling receivePresubmissionJson" should {
 
     "return BadRequest if invalid json is given" in {
       val presubmissionController = buildPresubmissionController(validationResult = false)
-      val result = await(presubmissionController.receivePresubmissionJson("")(FakeRequest().withBody(Fixtures.schemeDataJson)))
+      val result = await(presubmissionController.receivePresubmissionJson("")(FakeRequest().withBody(Fixtures.invalidJson)))
       status(result) shouldBe BAD_REQUEST
       verify(mockMetrics, VerificationModeFactory.times(0)).storePresubmission(_, _)
       verify(mockMetrics, VerificationModeFactory.times(0)).failedStorePresubmission()
@@ -102,12 +142,75 @@ class ReceivePresubmissionControllerSpec extends UnitSpec with MockitoSugar with
     }
 
     "return OK if valid json is given and storage succeeds" in {
-      val presubmissionController = buildPresubmissionController(validationResult = true, storeJsonResult = true)
+      val presubmissionController = buildPresubmissionController()
       val result = await(presubmissionController.receivePresubmissionJson("")(FakeRequest().withBody(Fixtures.schemeDataJson)))
       status(result) shouldBe OK
       verify(mockMetrics, VerificationModeFactory.times(1)).storePresubmission(_, _)
       verify(mockMetrics, VerificationModeFactory.times(0)).failedStorePresubmission()
     }
+  }
 
+  "calling receivePresubmissionJsonV2" should {
+
+    "return BadRequest if invalid json is given" in {
+      val presubmissionController = buildPresubmissionController(validationResult = false)
+      val result = await(presubmissionController.receivePresubmissionJsonV2("")(FakeRequest().withBody(Fixtures.invalidJson)))
+      status(result) shouldBe BAD_REQUEST
+      verify(mockMetrics, VerificationModeFactory.times(0)).storePresubmission(_, _)
+      verify(mockMetrics, VerificationModeFactory.times(0)).failedStorePresubmission()
+    }
+
+    "return INTERNAL_SERVER_ERROR if valid json is given but storage fails" in {
+      val presubmissionController = buildPresubmissionController(storeJsonResult = false)
+      when(mockPresubmissionService.removeJson(any())(any(), any())).thenReturn(Future(true))
+      val result = await(presubmissionController.receivePresubmissionJsonV2("")(FakeRequest().withBody(Fixtures.submissionsSchemeDataJson)))
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      verify(mockMetrics, VerificationModeFactory.times(0)).storePresubmission(_, _)
+      verify(mockMetrics, VerificationModeFactory.times(1)).failedStorePresubmission()
+    }
+
+    "return INTERNAL_SERVER_ERROR and log a warning if valid json is given, some data is stored and then failed to be removed" in {
+      val presubmissionController = buildPresubmissionController(mockSubmissionResult = true)
+      when(mockPresubmissionService.removeJson(any())(any(), any())).thenReturn(Future(false))
+      val result = await(presubmissionController.receivePresubmissionJsonV2("")(FakeRequest().withBody(Fixtures.submissionsSchemeDataJson)))
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      verify(mockMetrics, VerificationModeFactory.times(0)).storePresubmission(_, _)
+      verify(mockMetrics, VerificationModeFactory.times(1)).failedStorePresubmission()
+    }
+
+    "return OK if valid json and storage succeeds" in {
+      val presubmissionController = buildPresubmissionController()
+      val result = await(presubmissionController.receivePresubmissionJsonV2("")(FakeRequest().withBody(Fixtures.submissionsSchemeDataJson)))
+      status(result) shouldBe OK
+      verify(mockMetrics, VerificationModeFactory.times(1)).storePresubmission(_, _)
+      verify(mockMetrics, VerificationModeFactory.times(0)).failedStorePresubmission()
+    }
+
+  }
+
+  "calling storePresubmission" should {
+    "return InternalServerError when receiving an UpstreamErrorResponse from submitJson" in {
+      val submissionsSchemeData: SubmissionsSchemeData = SubmissionsSchemeData(SIP.schemeInfo, "sip sheet name",
+        UpscanCallback("name", "/download/url"), 1)
+
+      val presubmissionController = buildPresubmissionController(failSubmitJson = Some(UpstreamErrorResponse("a message", 500)))
+      val result = await(presubmissionController.storePresubmission(submissionsSchemeData)(FakeRequest().withBody(Fixtures.submissionsSchemeDataJson),
+        HeaderCarrier.apply()))
+
+      result.header.status shouldBe Status.INTERNAL_SERVER_ERROR
+      bodyOf(result) shouldBe "a message"
+    }
+
+    "return InternalServerError when receiving an unknown exception from submitJson" in {
+      val submissionsSchemeData: SubmissionsSchemeData = SubmissionsSchemeData(SIP.schemeInfo, "sip sheet name",
+        UpscanCallback("name", "/download/url"), 1)
+
+      val presubmissionController = buildPresubmissionController(failSubmitJson = Some(new RuntimeException("a different message")))
+      val result = await(presubmissionController.storePresubmission(submissionsSchemeData)(FakeRequest().withBody(Fixtures.submissionsSchemeDataJson),
+        HeaderCarrier.apply()))
+
+      result.header.status shouldBe Status.INTERNAL_SERVER_ERROR
+      bodyOf(result) shouldBe "a different message"
+    }
   }
 }

--- a/test/controllers/SubmissionControllerSpec.scala
+++ b/test/controllers/SubmissionControllerSpec.scala
@@ -25,7 +25,7 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.internal.verification.VerificationModeFactory
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.JsObject
 import play.api.mvc._

--- a/test/controllers/auth/AuthActionSpec.scala
+++ b/test/controllers/auth/AuthActionSpec.scala
@@ -17,11 +17,11 @@
 package controllers.auth
 
 import akka.stream.Materializer
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import uk.gov.hmrc.auth.core.{AuthConnector, BearerTokenExpired, ConfidenceLevel, Enrolment, InsufficientConfidenceLevel}
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import play.api.Play
 import play.api.http.Status

--- a/test/fixtures/Fixtures.scala
+++ b/test/fixtures/Fixtures.scala
@@ -17,10 +17,11 @@
 package fixtures
 
 import models._
-import org.joda.time.{DateTimeZone, DateTime}
-import play.api.libs.json.{Json, JsObject}
+import org.joda.time.{DateTime, DateTimeZone}
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.{JsObject, JsValue, Json}
+
 import scala.collection.mutable.ListBuffer
-import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.domain.Generator
 
 object Fixtures extends MockitoSugar {
@@ -39,6 +40,8 @@ object Fixtures extends MockitoSugar {
     schemeName = "My scheme",
     schemeType = "EMI"
   )
+
+  val schemeInfoJson: JsValue = Json.toJson(schemeInfo)
 
   val summaryData = ErsSummary(
     bundleRef = "123453222",
@@ -97,7 +100,7 @@ object Fixtures extends MockitoSugar {
     transferStatus = Some("saved")
   )
 
-  val scheetName: String = "EMI40_Adjustments_V3"
+  val sheetName: String = "EMI40_Adjustments_V3"
   val data: Option[ListBuffer[Seq[String]]] = Some(
     ListBuffer(
       Seq("no", "no", "yes", "3", "2015-12-09", "First", "", "Last", nino, "123/123456", "10.1234", "100.12", "10.1234", "10.1234"),
@@ -108,12 +111,21 @@ object Fixtures extends MockitoSugar {
 
   val schemeData: SchemeData = SchemeData(
     EMISchemeInfo,
-    scheetName,
+    sheetName,
     None,
     data
   )
 
+  val submissionsSchemeData: SubmissionsSchemeData = SubmissionsSchemeData(
+    EMISchemeInfo,
+    sheetName,
+    UpscanCallback(sheetName, "downloadUrl"),
+    1
+  )
+
   val schemeDataJson: JsObject = Json.toJson(schemeData).as[JsObject]
+
+  val submissionsSchemeDataJson: JsObject = Json.toJson(submissionsSchemeData).as[JsObject]
 
   val invalidJson: JsObject = Json.obj(
     "metafield1" -> "metavalue1",

--- a/test/services/FileDownloadServiceSpec.scala
+++ b/test/services/FileDownloadServiceSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, StatusCodes}
+import akka.stream.scaladsl.{Sink, Source}
+import akka.testkit.TestKit
+import akka.util.ByteString
+import config.ApplicationConfig
+import fixtures.SIP
+import models.{SchemeInfo, SubmissionsSchemeData, UpscanCallback}
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import org.mockito.Mockito._
+import org.scalatest.concurrent.ScalaFutures
+import uk.gov.hmrc.http.UpstreamErrorResponse
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
+
+class FileDownloadServiceSpec extends TestKit(ActorSystem("FileDownloadServiceSpec"))
+  with UnitSpec with MockitoSugar with WithFakeApplication {
+
+  val mockAppConfig: ApplicationConfig = mock[ApplicationConfig]
+  when(mockAppConfig.uploadCsvSizeLimit).thenReturn(10000)
+
+  "fileDownloadService" should {
+    "extract entity data" when {
+      "given a status 200 response" in {
+        val testService = new FileDownloadService(mockAppConfig)
+        val response: HttpResponse = HttpResponse(StatusCodes.OK, entity = HttpEntity.apply("gotABody"))
+
+        val result = Await.result(
+          testService.extractEntityData(response).runWith(Sink.seq),
+          Duration.Inf
+        )
+
+        result.length shouldBe 1
+        result.head.utf8String shouldBe "gotABody"
+
+      }
+
+      "given an unhappy response" in {
+        val testService = new FileDownloadService(mockAppConfig)
+        val response: HttpResponse = HttpResponse(StatusCodes.NotFound, entity = HttpEntity.apply("gotABody"))
+
+        val result = testService.extractEntityData(response).runWith(Sink.seq)
+
+        ScalaFutures.whenReady(result.failed) { e =>
+          e shouldBe an[UpstreamErrorResponse]
+        }
+
+      }
+    }
+
+    "extract body of request" in {
+      val testService = new FileDownloadService(mockAppConfig) {
+        override def extractEntityData(response: HttpResponse): Source[ByteString, _] =
+          Source.fromIterator(() => Seq(ByteString("aSingleRow,withTwoEntries\n"), ByteString("anotherRow")).toIterator)
+      }
+      val response: HttpResponse = HttpResponse(StatusCodes.OK, entity = HttpEntity.apply("gotABody"))
+
+      val result: Seq[List[ByteString]] = Await.result(
+        testService.extractBodyOfRequest(Source.single(response)).runWith(Sink.seq),
+        Duration.Inf
+      )
+
+      result.length shouldBe 2
+      result.head.map(_.utf8String) shouldBe List("aSingleRow", "withTwoEntries")
+      result.last.map(_.utf8String) shouldBe List("anotherRow")
+    }
+
+    "convert file to sequence of eithers" when {
+      val submissionsSchemeData: SubmissionsSchemeData = SubmissionsSchemeData(SIP.schemeInfo, "sip sheet name",
+        UpscanCallback("name", "/download/url"), 1)
+
+      val testService: FileDownloadService = new FileDownloadService(mockAppConfig) {
+        override def extractBodyOfRequest: Source[HttpResponse, _] => Source[List[ByteString], _] = {
+          _ =>
+            Source.fromIterator(() => List(
+              List(
+                ByteString("one"),
+                ByteString("two")),
+              List(
+                ByteString("three"),
+                ByteString("four"),
+                ByteString("five"))
+            ).toIterator)
+        }
+
+        override def streamFile(downloadUrl: String): Source[HttpResponse, _] =
+          Source.single(HttpResponse(StatusCodes.OK, entity = HttpEntity.apply("gotABody")))
+      }
+
+      "file has less than grouping-size rows" in {
+        val result = Await.result(testService
+          .schemeDataToChunksWithIndex(submissionsSchemeData, 10)
+          .runWith(Sink.seq),
+          Duration.Inf
+        )
+
+
+        result.length shouldBe 1
+        result.head._2 shouldBe 0
+        result.head._1.length shouldBe 2
+        result.head._1.head.map(_.utf8String) shouldBe Seq("one", "two")
+        result.head._1.last.map(_.utf8String) shouldBe Seq("three", "four", "five")
+      }
+
+      "file has more than grouping-size rows" in {
+        val result = Await.result(testService
+          .schemeDataToChunksWithIndex(submissionsSchemeData, 1)
+          .runWith(Sink.seq),
+          Duration.Inf
+        )
+
+
+        result.length shouldBe 2
+        result.head._2 shouldBe 0
+        result.head._1.length shouldBe 1
+        result.head._1.head.map(_.utf8String) shouldBe Seq("one", "two")
+
+        result.last._2 shouldBe 1
+        result.last._1.length shouldBe 1
+        result.last._1.last.map(_.utf8String) shouldBe Seq("three", "four", "five")
+      }
+    }
+
+    "streamFile" should {
+      "process file" in {
+        val testService = new FileDownloadService(mockAppConfig) {
+          override def makeRequest(request: HttpRequest): Future[HttpResponse] = Future.successful(HttpResponse(StatusCodes.OK))
+        }
+
+        val result = Await.result(testService.streamFile("http://thisIsNot.aRealPage").runWith(Sink.seq),
+          Duration.Inf)
+
+        result.length shouldBe 1
+        result.head shouldBe HttpResponse(StatusCodes.OK)
+      }
+    }
+
+  }
+
+}

--- a/test/services/MetadataServiceSpec.scala
+++ b/test/services/MetadataServiceSpec.scala
@@ -20,9 +20,8 @@ import fixtures.Fixtures
 import models.ErsSummary
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterEach}
-import org.scalatest.mockito.MockitoSugar
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest
 import repositories.{MetadataMongoRepository, Repositories}
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/services/SubmissionCommonServiceSpec.scala
+++ b/test/services/SubmissionCommonServiceSpec.scala
@@ -26,7 +26,7 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.internal.verification.VerificationModeFactory
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Request
@@ -34,7 +34,7 @@ import play.api.test.FakeRequest
 import repositories.{MetadataMongoRepository, Repositories}
 import services.audit.AuditEvents
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 import utils.LoggingAndRexceptions.{ADRExceptionEmitter, ErsLoggingAndAuditing}
 import utils.{ADRSubmission, SubmissionCommon}
 

--- a/test/services/audit/AuditEventsTest.scala
+++ b/test/services/audit/AuditEventsTest.scala
@@ -19,22 +19,17 @@ package services
 import fixtures.Fixtures
 import fixtures.Fixtures.schemeData
 import models.{ErsMetaData, SchemeInfo}
-import org.apache.commons.lang3.exception.ExceptionUtils
 import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify}
 import org.mockito.internal.verification.VerificationModeFactory
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.test.FakeRequest
 import services.audit.{AuditEvents, AuditService}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.audit.http.config.{AuditingConfig, BaseUri, Consumer}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
-import uk.gov.hmrc.play.audit.model.DataEvent
-
-import scala.collection.mutable.ListBuffer
 
 class AuditEventsTest
   extends WordSpec with Matchers with MockitoSugar with GuiceOneAppPerSuite with BeforeAndAfterEach {

--- a/test/services/audit/AuditServiceTest.scala
+++ b/test/services/audit/AuditServiceTest.scala
@@ -19,7 +19,7 @@ package services
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
 import org.mockito.internal.verification.VerificationModeFactory
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest

--- a/test/services/query/DataVerificationServiceSpec.scala
+++ b/test/services/query/DataVerificationServiceSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import models.ERSQuery
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import repositories.{DataVerificationMongoRepository, Repositories}
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/services/resubmission/ResubPresubmissionServiceSpec.scala
+++ b/test/services/resubmission/ResubPresubmissionServiceSpec.scala
@@ -22,7 +22,7 @@ import models.{ADRTransferException, ErsSummary, ResubmissionException}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.mvc.Request
 import play.api.test.FakeRequest

--- a/test/services/resubmission/SchedulerServiceSpec.scala
+++ b/test/services/resubmission/SchedulerServiceSpec.scala
@@ -21,7 +21,7 @@ import config.ApplicationConfig
 import org.joda.time.DateTime
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.mvc.Request
 import play.api.test.FakeRequest

--- a/test/utils/ADRSubmissionSpec.scala
+++ b/test/utils/ADRSubmissionSpec.scala
@@ -22,13 +22,13 @@ import models.{ADRTransferException, ErsSummary, SchemeInfo}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Request
 import play.api.test.FakeRequest
 import services.PresubmissionService
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future

--- a/test/utils/ConfigUtilsSpec.scala
+++ b/test/utils/ConfigUtilsSpec.scala
@@ -18,11 +18,11 @@ package utils
 
 import fixtures.Fixtures
 import models.{ADRTransferException, ErsSummary}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.LoggingAndRexceptions.ADRExceptionEmitter
 

--- a/test/utils/LoggingAndExceptions/ADRExceptionEmitterSpec.scala
+++ b/test/utils/LoggingAndExceptions/ADRExceptionEmitterSpec.scala
@@ -18,7 +18,7 @@ package utils.LoggingAndExceptions
 
 import fixtures.Fixtures
 import models.ADRTransferException
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest
 import services.audit.AuditEvents
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/utils/LoggingAndExceptions/ErsLoggerSpec.scala
+++ b/test/utils/LoggingAndExceptions/ErsLoggerSpec.scala
@@ -69,16 +69,4 @@ class ErsLoggerSpec extends UnitSpec {
     }
   }
 
-  "calling logSliced" should {
-    "log list data in chuncks" in {
-      val testData = List(
-        List.fill(20)("test"),
-        List.fill(21)("test")
-      )
-      testData.map { testList =>
-        val result = TestErsLogger.logSliced(testList, "length message", "data message")
-        result shouldBe (())
-      }
-    }
-  }
 }

--- a/test/utils/LoggingAndExceptions/ErsLoggingAndAuditingSpec.scala
+++ b/test/utils/LoggingAndExceptions/ErsLoggingAndAuditingSpec.scala
@@ -18,7 +18,7 @@ package utils.LoggingAndExceptions
 
 import fixtures.Fixtures
 import models.ADRTransferException
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest
 import services.audit.AuditEvents
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/utils/LoggingAndExceptions/ResubmissionExceptionEmiterSpec.scala
+++ b/test/utils/LoggingAndExceptions/ResubmissionExceptionEmiterSpec.scala
@@ -17,7 +17,7 @@
 package utils.LoggingAndExceptions
 
 import models.ResubmissionException
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest
 import services.audit.AuditEvents
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/utils/Schemes_ADRSubmissionSpec/CSOP_ADRSubmissionSpec.scala
+++ b/test/utils/Schemes_ADRSubmissionSpec/CSOP_ADRSubmissionSpec.scala
@@ -21,14 +21,14 @@ import fixtures.{CSOP, Common, Fixtures}
 import models.{SchemeData, SchemeInfo}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.ArgumentMatchers._
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Request
 import play.api.test.FakeRequest
 import services.PresubmissionService
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 import utils.{ADRSubmission, ConfigUtils, SubmissionCommon}
 
 import scala.concurrent.Future

--- a/test/utils/Schemes_ADRSubmissionSpec/EMI_ADRSubmissionSpec.scala
+++ b/test/utils/Schemes_ADRSubmissionSpec/EMI_ADRSubmissionSpec.scala
@@ -22,13 +22,12 @@ import models.{SchemeData, SchemeInfo}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.Json
-import play.api.mvc.Request
 import play.api.test.FakeRequest
 import services.PresubmissionService
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 import utils.{ADRSubmission, ConfigUtils, SubmissionCommon}
 
 import scala.collection.mutable.ListBuffer

--- a/test/utils/Schemes_ADRSubmissionSpec/OTHER_ADRSubmissionSpec.scala
+++ b/test/utils/Schemes_ADRSubmissionSpec/OTHER_ADRSubmissionSpec.scala
@@ -22,7 +22,7 @@ import models.{SchemeData, SchemeInfo}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json._
 import play.api.test.FakeRequest

--- a/test/utils/Schemes_ADRSubmissionSpec/SAYE_ADRSubmissionSpec.scala
+++ b/test/utils/Schemes_ADRSubmissionSpec/SAYE_ADRSubmissionSpec.scala
@@ -22,13 +22,12 @@ import models.{SchemeData, SchemeInfo}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.Json
-import play.api.mvc.Request
 import play.api.test.FakeRequest
 import services.PresubmissionService
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 import utils.{ADRSubmission, ConfigUtils, SubmissionCommon}
 
 import scala.collection.mutable.ListBuffer

--- a/test/utils/Schemes_ADRSubmissionSpec/SIP_ADRSubmissionSpec.scala
+++ b/test/utils/Schemes_ADRSubmissionSpec/SIP_ADRSubmissionSpec.scala
@@ -22,13 +22,12 @@ import models.{SchemeData, SchemeInfo}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.Json
-import play.api.mvc.Request
 import play.api.test.FakeRequest
 import services.PresubmissionService
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 import utils.{ADRSubmission, ConfigUtils, SubmissionCommon}
 
 import scala.collection.mutable.ListBuffer

--- a/test/utils/SubmissionCommonSpec.scala
+++ b/test/utils/SubmissionCommonSpec.scala
@@ -19,12 +19,12 @@ package utils
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import fixtures.Common
 import org.joda.time.{DateTime, DateTimeZone}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsObject, Json}
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.http.HttpResponse
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 
 class SubmissionCommonSpec extends UnitSpec with MockitoSugar with GuiceOneAppPerSuite {
 


### PR DESCRIPTION
# DDCE-1770
Changes for efficiency. The file is no longer passed in a payload from ers-file-validator to ers-submissions; instead, EFV passes the Upscan download link to ES, which redownloads it and streams it into mongo. It splits the document into chunks (due to each document in Mongo having a max size of ~16mb); by default, it's 10000, but that can be adjusted in the app-configs.

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date