### PR TITLE
[DDCE] Remove log causing issues

### DIFF
--- a/app/connectors/ADRConnector.scala
+++ b/app/connectors/ADRConnector.scala
@@ -44,7 +44,7 @@ class ADRConnector @Inject()(applicationConfig: ApplicationConfig,
       s"url: $url")
 
     http.POST(url, adrData, headers = hc.headers(Seq("Authorization"))).map { res =>
-      logger.warn(s"ADR response: ${res.status} and json: ${res.json}")
+      logger.warn(s"ADR response: ${res.status}")
       res
     }.recover {
       case ex: Exception =>


### PR DESCRIPTION
The success response from ADR doesn't have a body, so when we try to read the json body it throws an exception "no content to map due to end of input".

Removing the log 