### PR TITLE
[EH][DDCE-1868] Added x-correlation-id to outbound ADR rq

### DIFF
--- a/app/controllers/SubmissionController.scala
+++ b/app/controllers/SubmissionController.scala
@@ -30,6 +30,8 @@ import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import utils.LoggingAndRexceptions.ErsLoggingAndAuditing
 
 import scala.concurrent.{ExecutionContext, Future}
+import utils.CorrelationIdHelper
+import uk.gov.hmrc.http.HeaderCarrier
 
 class SubmissionController @Inject()(submissionCommonService: SubmissionService,
                                      metadataService: MetadataService,
@@ -37,9 +39,10 @@ class SubmissionController @Inject()(submissionCommonService: SubmissionService,
                                      ersLoggingAndAuditing: ErsLoggingAndAuditing,
                                      auditEvents: AuditEvents,
                                      cc: ControllerComponents)
-                                    (implicit val ec: ExecutionContext) extends BackendController(cc) {
+                                    (implicit val ec: ExecutionContext) extends BackendController(cc) with CorrelationIdHelper {
 
   def receiveMetadataJson(): Action[JsObject] = Action.async(parse.json[JsObject]) { implicit request =>
+    implicit val hc: HeaderCarrier = getOrCreateCorrelationID(request)
     ersLoggingAndAuditing.logWarn(s"Submission journey 1. received request: ${DateTime.now}")
 
     metadataService.validateErsSummaryFromJson(request.body) match {

--- a/app/utils/CorrelationIDHelper.scala
+++ b/app/utils/CorrelationIDHelper.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import java.util.UUID
+import play.api.mvc.Request
+
+trait CorrelationIdHelper {
+  protected val HEADER_X_CORRELATION_ID: String = "X-Correlation-Id"
+  protected def getOrCreateCorrelationID(request: Request[_]): HeaderCarrier = {
+    val hcFromRequest: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
+    val hc: HeaderCarrier =
+      hcFromRequest
+        .headers(Seq(HEADER_X_CORRELATION_ID)) match {
+          case Nil =>
+            hcFromRequest
+              .withExtraHeaders((
+                HEADER_X_CORRELATION_ID,
+                UUID
+                  .randomUUID()
+                  .toString()
+              ))
+          case _ =>
+            hcFromRequest
+        }
+    hc
+  }
+}

--- a/test/services/SubmissionCommonServiceSpec.scala
+++ b/test/services/SubmissionCommonServiceSpec.scala
@@ -192,7 +192,7 @@ class SubmissionCommonServiceSpec extends ERSTestHelper with BeforeAndAfterEach 
     }
 
     "return result from updatePostsubmission if sending to ADR is successful" in {
-      when(adrConnector.sendData(any[JsObject](), anyString())(any[ExecutionContext]()))
+      when(adrConnector.sendData(any[JsObject](), anyString())(any[ExecutionContext](), any[HeaderCarrier]()))
         .thenReturn(Future.successful(HttpResponse(202, "")))
 
       val result = await(submissionCommonService.sendToADRUpdatePostData(Fixtures.metadata, Fixtures.metadataJson, Statuses.Failed.toString, Statuses.Sent.toString))
@@ -203,7 +203,7 @@ class SubmissionCommonServiceSpec extends ERSTestHelper with BeforeAndAfterEach 
     }
 
     "return result from updatePostsubmission if sending to ADR failed" in {
-      when(adrConnector.sendData(any[JsObject](), anyString())(any[ExecutionContext]()))
+      when(adrConnector.sendData(any[JsObject](), anyString())(any[ExecutionContext](), any[HeaderCarrier]()))
         .thenReturn(Future.successful(HttpResponse(500, "")))
 
       val result = await(submissionCommonService.sendToADRUpdatePostData(Fixtures.metadata, Fixtures.metadataJson, Statuses.Failed.toString, Statuses.Sent.toString))
@@ -214,7 +214,7 @@ class SubmissionCommonServiceSpec extends ERSTestHelper with BeforeAndAfterEach 
     }
 
     "re-throws ADRTransferException if sending to ADR or update throws ADRTransferException exception" in {
-      when(adrConnector.sendData(any[JsObject](), anyString())(any[ExecutionContext]()))
+      when(adrConnector.sendData(any[JsObject](), anyString())(any[ExecutionContext](), any[HeaderCarrier]()))
         .thenReturn(Future.failed(new ADRTransferException(Fixtures.metadata.metaData, "errorMessage", "errorContext")))
 
       intercept[ADRTransferException] {
@@ -226,7 +226,7 @@ class SubmissionCommonServiceSpec extends ERSTestHelper with BeforeAndAfterEach 
     }
 
     "throws ADRTransferException if sending to ADR or update throws exception" in {
-      when(adrConnector.sendData(any[JsObject](), anyString())(any[ExecutionContext]())).thenReturn(Future.failed(new Exception("errorMessage")))
+      when(adrConnector.sendData(any[JsObject](), anyString())(any[ExecutionContext](), any[HeaderCarrier]())).thenReturn(Future.failed(new Exception("errorMessage")))
 
       intercept[ADRTransferException] {
         await(submissionCommonService.sendToADRUpdatePostData(Fixtures.metadata, Fixtures.metadataJson, Statuses.Failed.toString, Statuses.Sent.toString))


### PR DESCRIPTION
# DDCE-1868

- Explicitly passing Auth, Env and x-correlation-id headers to ADR

- [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
- [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
- [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
- [x]  I've squashed my commits - including the JIRA issue number in the commit message
- [ ]  I've run a dependency check to ensure all dependencies are up to date