### PR TITLE
DDCE-3746 | Implemented scheduler to add createdAt field to records in the pre-submission repository.

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -24,7 +24,6 @@ import scala.util.Try
 
 class ApplicationConfig @Inject()(serviceConfig: ServicesConfig) {
 
-
   lazy val presubmissionCollection: String = serviceConfig.getString("settings.presubmission-collection")
   lazy val presubmissionCollectionTTL: Int = serviceConfig.getInt("settings.presubmission-collection-ttl-days")
   lazy val metadataCollection: String = serviceConfig.getString("settings.metadata-collection")

--- a/app/config/ModuleBindings.scala
+++ b/app/config/ModuleBindings.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import play.api.inject.{Binding, Module}
+import play.api.{Configuration, Environment}
+import repositories.{DefaultLockRepositoryProvider, LockRepositoryProvider}
+import scheduler.{UpdateCreatedAtFieldsJob, UpdateCreatedAtFieldsJobImpl}
+import services.{DefaultDocumentUpdateService, DocumentUpdateService}
+
+class ModuleBindings extends Module {
+
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
+    bind[LockRepositoryProvider].to[DefaultLockRepositoryProvider],
+    bind[DocumentUpdateService].to[DefaultDocumentUpdateService],
+    bind[UpdateCreatedAtFieldsJob].to[UpdateCreatedAtFieldsJobImpl].eagerly()
+  )
+}

--- a/app/controllers/PresubmissionController.scala
+++ b/app/controllers/PresubmissionController.scala
@@ -17,7 +17,6 @@
 package controllers
 
 import java.util.concurrent.TimeUnit
-
 import javax.inject.Inject
 import metrics.Metrics
 import models.SchemeInfo
@@ -28,14 +27,13 @@ import services.{PresubmissionService, ValidationService}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import utils.LoggingAndRexceptions.ErsLoggingAndAuditing
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class PresubmissionController @Inject()(presubmissionService: PresubmissionService,
                                         validationService: ValidationService,
                                         ersLoggingAndAuditing: ErsLoggingAndAuditing,
                                         metrics: Metrics,
-                                        cc: ControllerComponents) extends BackendController(cc) with Logging{
+                                        cc: ControllerComponents)(implicit ec: ExecutionContext) extends BackendController(cc) with Logging{
 
 
   def removePresubmissionJson(): Action[JsObject] = Action.async(parse.json[JsObject]) { implicit request =>

--- a/app/models/RepositoryUpdateMessage.scala
+++ b/app/models/RepositoryUpdateMessage.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+trait RepositoryUpdateMessage {
+  val message: String
+}
+
+case object UpdateRequestNotAcknowledged extends RepositoryUpdateMessage {
+  override val message: String = "Request to update presubmission repository was not acknowledged. Data was not updated."
+}
+
+case object UpdateRequestAcknowledgedNothingToUpdate extends RepositoryUpdateMessage {
+  override val message: String = "There is no more documents to update. Consider disabling scheduler."
+}
+
+case object FailedToLockRepositoryForUpdate extends RepositoryUpdateMessage {
+  override val message: String = "Failed to acquire lock. Update job not completed."
+}
+
+case class UpdateRequestAcknowledged(count: Long) extends RepositoryUpdateMessage {
+  override val message: String = s"Updated $count document(s) with createdAt field."
+}
+
+case class UpdateRepositoryError(error: String) extends RepositoryUpdateMessage {
+  override val message: String = s"Exception occured when tried to perform update. Exception: $error."
+}

--- a/app/models/RepositoryUpdateMessage.scala
+++ b/app/models/RepositoryUpdateMessage.scala
@@ -24,7 +24,7 @@ case object UpdateRequestNotAcknowledged extends RepositoryUpdateMessage {
   override val message: String = "Request to update presubmission repository was not acknowledged. Data was not updated."
 }
 
-case object UpdateRequestAcknowledgedNothingToUpdate extends RepositoryUpdateMessage {
+case object UpdateRequestNothingToUpdate extends RepositoryUpdateMessage {
   override val message: String = "There is no more documents to update. Consider disabling scheduler."
 }
 

--- a/app/models/RepositoryUpdateMessage.scala
+++ b/app/models/RepositoryUpdateMessage.scala
@@ -17,25 +17,22 @@
 package models
 
 trait RepositoryUpdateMessage {
+  val prefix: String = "[DocumentUpdateService]"
   val message: String
 }
 
 case object UpdateRequestNotAcknowledged extends RepositoryUpdateMessage {
-  override val message: String = "Request to update presubmission repository was not acknowledged. Data was not updated."
+  override val message: String = s"$prefix Request to update presubmission repository was not acknowledged. Data was not updated."
 }
 
 case object UpdateRequestNothingToUpdate extends RepositoryUpdateMessage {
-  override val message: String = "There is no more documents to update. Consider disabling scheduler."
+  override val message: String = s"$prefix There is no more documents to update. Consider disabling scheduler."
 }
 
 case object FailedToLockRepositoryForUpdate extends RepositoryUpdateMessage {
-  override val message: String = "Failed to acquire lock. Update job not completed."
+  override val message: String = s"$prefix Failed to acquire lock. Update job not completed."
 }
 
 case class UpdateRequestAcknowledged(count: Long) extends RepositoryUpdateMessage {
-  override val message: String = s"Updated $count document(s) with createdAt field."
-}
-
-case class UpdateRepositoryError(error: String) extends RepositoryUpdateMessage {
-  override val message: String = s"Exception occured when tried to perform update. Exception: $error."
+  override val message: String = s"$prefix Updated $count document(s) with createdAt field."
 }

--- a/app/repositories/LockRepositoryImpl.scala
+++ b/app/repositories/LockRepositoryImpl.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import com.google.inject.Inject
+import uk.gov.hmrc.mongo.lock._
+
+trait LockRepositoryProvider {
+  val repo: MongoLockRepository
+}
+
+class DefaultLockRepositoryProvider @Inject()(component: MongoLockRepository) extends LockRepositoryProvider {
+  lazy val repo: MongoLockRepository = component
+}

--- a/app/repositories/PresubmissionMongoRepository.scala
+++ b/app/repositories/PresubmissionMongoRepository.scala
@@ -17,19 +17,24 @@
 package repositories
 
 import config.ApplicationConfig
-import models.{SchemeData, SchemeInfo}
-import org.mongodb.scala.bson.{BsonDocument, BsonInt64, BsonString}
+import models._
+import org.mongodb.scala.bson.{BsonDocument, BsonInt64, BsonString, ObjectId}
 import org.mongodb.scala.model.Sorts._
-import org.mongodb.scala.model.{IndexModel, IndexOptions}
+import org.mongodb.scala.model.Updates.set
+import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions}
+import org.mongodb.scala.result.UpdateResult
 import play.api.Logging
+import play.api.libs.json.OFormat.oFormatFromReadsAndOWrites
 import play.api.libs.json.{Format, JsObject, Json}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.mongo.play.json.formats.MongoFormats
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 @Singleton
 class PresubmissionMongoRepository @Inject()(applicationConfig: ApplicationConfig, mc: MongoComponent)
@@ -96,4 +101,31 @@ class PresubmissionMongoRepository @Inject()(applicationConfig: ApplicationConfi
     }
   }
 
+  def getDocumentIdsWithoutCreatedAtField(updateLimit: Int): Future[Seq[ObjectId]] = {
+    collection
+      .find(Filters.and(Filters.exists("createdAt", exists = false)))
+      .limit(updateLimit)
+        .map(json => (json \ "_id").as[ObjectId](MongoFormats.objectIdFormat))
+      .toFuture()
+  }
+
+  def addCreatedAtField(documentIds: Seq[ObjectId]): Future[Either[RepositoryUpdateMessage, UpdateResult]] = {
+    Try {
+      require(documentIds.nonEmpty, "list of IDs for update cannot be empty")
+
+      collection.updateMany(Filters.in("_id", documentIds: _*),
+        Seq(set("createdAt", BsonDocument("$toDate" -> "$schemeInfo.timestamp")))).toFuture()
+    }.toEither match {
+      case Left(exception) => handleException(exception)
+      case Right(updateResultF) =>
+        updateResultF map {
+          case result if !result.wasAcknowledged() => Left(UpdateRequestNotAcknowledged)
+          case result => Right(result)
+        }
+    }
+  }
+
+  private def handleException[T](exception: Throwable): Future[Left[RepositoryUpdateMessage, T]] = {
+    Future.successful(Left(UpdateRepositoryError(exception.getMessage)))
+  }
 }

--- a/app/scheduler/ScheduledJob.scala
+++ b/app/scheduler/ScheduledJob.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scheduler
+
+import akka.actor.{ActorRef, ActorSystem}
+import com.typesafe.akka.extension.quartz.QuartzSchedulerExtension
+import org.quartz.CronExpression
+import play.api.{Configuration, Logging}
+import scheduler.SchedulingActor.ScheduledMessage
+
+import java.time.ZoneId
+import java.util.TimeZone
+
+trait ScheduledJob extends Logging {
+  val scheduledMessage: ScheduledMessage[_]
+  val config: Configuration
+  val actorSystem: ActorSystem
+  def jobName: String
+
+  lazy val scheduler: QuartzSchedulerExtension = QuartzSchedulerExtension(actorSystem)
+
+  private lazy val schedulingActorRef: ActorRef = actorSystem.actorOf(SchedulingActor.props)
+
+  private[scheduler] lazy val enabled: Boolean = config.getOptional[Boolean](s"schedules.$jobName.enabled").getOrElse(false)
+
+  private lazy val description: Option[String] = config.getOptional[String](s"schedules.$jobName.description")
+
+  private[scheduler] lazy val expression: String = config.getOptional[String](s"schedules.$jobName.expression") map (_.replaceAll("_", " ")) getOrElse ""
+
+  private lazy val timezone: String = config.getOptional[String](s"schedules.$jobName.timezone").getOrElse(TimeZone.getDefault.getID)
+
+  private[scheduler] lazy val isValid = expression.nonEmpty && CronExpression.isValidExpression(expression)
+
+  lazy val schedule: Boolean = {
+    (enabled, isValid) match {
+      case (true, true) =>
+        scheduler.createSchedule(jobName, description, expression, None, TimeZone.getTimeZone(ZoneId.of(timezone)))
+        scheduler.schedule(jobName, schedulingActorRef, scheduledMessage)
+        logger.info(s"Scheduler for $jobName has been started")
+        true
+      case (true, false) =>
+        logger.info(s"Scheduler for $jobName is disabled as there is no quartz expression or expression is not valid")
+        false
+      case (false, _) =>
+        logger.info(s"Scheduler for $jobName is disabled by configuration")
+        false
+    }
+  }
+}

--- a/app/scheduler/ScheduledService.scala
+++ b/app/scheduler/ScheduledService.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scheduler
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait ScheduledService[R] {
+  val jobName: String
+
+  def invoke(implicit ec : ExecutionContext) : Future[R]
+}

--- a/app/scheduler/SchedulingActor.scala
+++ b/app/scheduler/SchedulingActor.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scheduler
+
+import akka.actor.{Actor, ActorLogging, Props}
+import scheduler.SchedulingActor._
+import services.DocumentUpdateService
+class SchedulingActor extends Actor with ActorLogging {
+  import context.dispatcher
+
+  override def receive: Receive = {
+    case message: ScheduledMessage[_] =>
+      log.info(s"Received update request from the ${message.getClass.getSimpleName}")
+      message.service.invoke
+  }
+}
+
+object SchedulingActor {
+  sealed trait ScheduledMessage[A] {
+    val service: ScheduledService[A]
+  }
+
+  def props: Props = Props[SchedulingActor]
+
+  case class UpdateDocumentsClass(service: DocumentUpdateService) extends ScheduledMessage[Long]
+}

--- a/app/scheduler/SchedulingActor.scala
+++ b/app/scheduler/SchedulingActor.scala
@@ -37,5 +37,5 @@ object SchedulingActor {
 
   def props: Props = Props[SchedulingActor]
 
-  case class UpdateDocumentsClass(service: DocumentUpdateService) extends ScheduledMessage[Long]
+  case class UpdateDocumentsClass(service: DocumentUpdateService) extends ScheduledMessage[Boolean]
 }

--- a/app/scheduler/SchedulingActor.scala
+++ b/app/scheduler/SchedulingActor.scala
@@ -19,6 +19,7 @@ package scheduler
 import akka.actor.{Actor, ActorLogging, Props}
 import scheduler.SchedulingActor._
 import services.DocumentUpdateService
+
 class SchedulingActor extends Actor with ActorLogging {
   import context.dispatcher
 

--- a/app/scheduler/UpdateCreatedAtFieldsJob.scala
+++ b/app/scheduler/UpdateCreatedAtFieldsJob.scala
@@ -29,7 +29,7 @@ class UpdateCreatedAtFieldsJobImpl @Inject()(
                                               val documentUpdateService: DocumentUpdateService
                                             ) extends UpdateCreatedAtFieldsJob {
 
-  override def jobName: String = "UpdateCreatedAtFieldJob"
+  override def jobName: String = "update-created-at-field-job"
   val actorSystem: ActorSystem = ActorSystem(jobName)
   val scheduledMessage: UpdateDocumentsClass = UpdateDocumentsClass(documentUpdateService)
 

--- a/app/scheduler/UpdateCreatedAtFieldsJob.scala
+++ b/app/scheduler/UpdateCreatedAtFieldsJob.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scheduler
+
+import akka.actor.ActorSystem
+import com.google.inject.Inject
+import play.api.Configuration
+import scheduler.SchedulingActor.UpdateDocumentsClass
+import services.DocumentUpdateService
+
+trait UpdateCreatedAtFieldsJob extends ScheduledJob
+
+class UpdateCreatedAtFieldsJobImpl @Inject()(
+                                              val config: Configuration,
+                                              val documentUpdateService: DocumentUpdateService
+                                            ) extends UpdateCreatedAtFieldsJob {
+
+  override def jobName: String = "UpdateCreatedAtFieldJob"
+  val actorSystem: ActorSystem = ActorSystem(jobName)
+  val scheduledMessage: UpdateDocumentsClass = UpdateDocumentsClass(documentUpdateService)
+
+  schedule
+}

--- a/app/services/DocumentUpdateService.scala
+++ b/app/services/DocumentUpdateService.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import com.google.inject.Inject
+import models.{FailedToLockRepositoryForUpdate, RepositoryUpdateMessage, UpdateRequestAcknowledged, UpdateRequestAcknowledgedNothingToUpdate}
+import play.api.Logging
+import repositories.{LockRepositoryProvider, PresubmissionMongoRepository}
+import scheduler.ScheduledService
+import uk.gov.hmrc.mongo.lock.LockService
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import scala.concurrent.duration.{Duration, SECONDS}
+import scala.concurrent.{ExecutionContext, Future}
+
+trait DocumentUpdateService extends ScheduledService[Long] with Logging
+class DefaultDocumentUpdateService @Inject()(repository: PresubmissionMongoRepository,
+                                             lockRepositoryProvider: LockRepositoryProvider,
+                                             servicesConfig: ServicesConfig
+                                            )(implicit ec: ExecutionContext) extends DocumentUpdateService {
+
+  override val jobName: String = "UpdateCreatedAtFieldJob"
+  private val updateLimit: Int = servicesConfig.getInt("schedules.UpdateCreatedAtFieldJob.updateLimit")
+  private lazy val lockoutTimeout: Int = servicesConfig.getInt("schedules.UpdateCreatedAtFieldJob.lockTimeout")
+  private val lockService: LockService = LockService(lockRepositoryProvider.repo, lockId = "update-created-at-job-lock",
+    ttl = Duration.create(lockoutTimeout, SECONDS))
+
+  private[services] def updateMissingCreatedAtFields(): Future[(Long, RepositoryUpdateMessage)] = {
+    repository.getDocumentIdsWithoutCreatedAtField(updateLimit).flatMap { documentIds =>
+      if(documentIds.nonEmpty) {
+        for {
+          updateResult <- repository.addCreatedAtField(documentIds)
+        } yield updateResult match {
+          case Left(error) => (0, error)
+          case Right(result) => (result.getModifiedCount, UpdateRequestAcknowledged(result.getModifiedCount))
+
+        }
+      } else {
+        Future.successful((0, UpdateRequestAcknowledgedNothingToUpdate))
+      }
+    }
+  }
+
+  override def invoke(implicit ec: ExecutionContext): Future[Long] =
+    lockService.withLock(updateMissingCreatedAtFields()) map {
+      case Some((updatedCount, updateMessage)) =>
+        logger.info("[DocumentUpdateService] - " + updateMessage.message)
+        updatedCount
+      case None =>
+        logger.info("[DocumentUpdateService] - " + FailedToLockRepositoryForUpdate.message)
+        0
+    }
+}

--- a/app/services/DocumentUpdateService.scala
+++ b/app/services/DocumentUpdateService.scala
@@ -17,7 +17,7 @@
 package services
 
 import com.google.inject.Inject
-import models.{FailedToLockRepositoryForUpdate, RepositoryUpdateMessage, UpdateRequestAcknowledged, UpdateRequestAcknowledgedNothingToUpdate}
+import models.{FailedToLockRepositoryForUpdate, RepositoryUpdateMessage, UpdateRequestAcknowledged, UpdateRequestNothingToUpdate}
 import play.api.Logging
 import repositories.{LockRepositoryProvider, PresubmissionMongoRepository}
 import scheduler.ScheduledService
@@ -34,8 +34,8 @@ class DefaultDocumentUpdateService @Inject()(repository: PresubmissionMongoRepos
                                             )(implicit ec: ExecutionContext) extends DocumentUpdateService {
 
   override val jobName: String = "update-created-at-field-job"
-  private val updateLimit: Int = servicesConfig.getInt("schedules.update-created-at-field-job.updateLimit")
-  private lazy val lockoutTimeout: Int = servicesConfig.getInt("schedules.update-created-at-field-job.lockTimeout")
+  private val updateLimit: Int = servicesConfig.getInt(s"schedules.$jobName.updateLimit")
+  private lazy val lockoutTimeout: Int = servicesConfig.getInt(s"schedules.$jobName.lockTimeout")
   private val lockService: LockService = LockService(lockRepositoryProvider.repo, lockId = "update-created-at-job-lock",
     ttl = Duration.create(lockoutTimeout, SECONDS))
 
@@ -50,7 +50,7 @@ class DefaultDocumentUpdateService @Inject()(repository: PresubmissionMongoRepos
 
         }
       } else {
-        Future.successful((0, UpdateRequestAcknowledgedNothingToUpdate))
+        Future.successful((0, UpdateRequestNothingToUpdate))
       }
     }
   }

--- a/app/services/DocumentUpdateService.scala
+++ b/app/services/DocumentUpdateService.scala
@@ -33,9 +33,9 @@ class DefaultDocumentUpdateService @Inject()(repository: PresubmissionMongoRepos
                                              servicesConfig: ServicesConfig
                                             )(implicit ec: ExecutionContext) extends DocumentUpdateService {
 
-  override val jobName: String = "UpdateCreatedAtFieldJob"
-  private val updateLimit: Int = servicesConfig.getInt("schedules.UpdateCreatedAtFieldJob.updateLimit")
-  private lazy val lockoutTimeout: Int = servicesConfig.getInt("schedules.UpdateCreatedAtFieldJob.lockTimeout")
+  override val jobName: String = "update-created-at-field-job"
+  private val updateLimit: Int = servicesConfig.getInt("schedules.update-created-at-field-job.updateLimit")
+  private lazy val lockoutTimeout: Int = servicesConfig.getInt("schedules.update-created-at-field-job.lockTimeout")
   private val lockService: LockService = LockService(lockRepositoryProvider.repo, lockId = "update-created-at-job-lock",
     ttl = Duration.create(lockoutTimeout, SECONDS))
 

--- a/app/services/MetadataService.scala
+++ b/app/services/MetadataService.scala
@@ -24,10 +24,10 @@ import uk.gov.hmrc.http.HeaderCarrier
 import utils.LoggingAndRexceptions.ErsLoggingAndAuditing
 
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class MetadataService @Inject()(metadataMongoRepository: MetadataMongoRepository, ersLoggingAndAuditing: ErsLoggingAndAuditing)
+class MetadataService @Inject()(metadataMongoRepository: MetadataMongoRepository,
+                                ersLoggingAndAuditing: ErsLoggingAndAuditing)(implicit ec: ExecutionContext)
   extends Logging {
 
   lazy val metadataRepository: MetadataMongoRepository = metadataMongoRepository

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -32,8 +32,7 @@ import utils.{ADRSubmission, SubmissionCommon}
 
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class SubmissionService @Inject()(repositories: Repositories,
                                   adrConnector: ADRConnector,
@@ -42,7 +41,7 @@ class SubmissionService @Inject()(repositories: Repositories,
                                   ersLoggingAndAuditing: ErsLoggingAndAuditing,
                                   adrExceptionEmitter: ADRExceptionEmitter,
                                   auditEvents: AuditEvents,
-                                  metrics: Metrics) extends Logging {
+                                  metrics: Metrics)(implicit ec: ExecutionContext) extends Logging {
 
   lazy val metadataRepository: MetadataMongoRepository = repositories.metadataRepository
 

--- a/app/services/audit/AuditService.scala
+++ b/app/services/audit/AuditService.scala
@@ -22,9 +22,9 @@ import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.DataEvent
 
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 
-class AuditService @Inject()(auditConnector: AuditConnector) {
+class AuditService @Inject()(auditConnector: AuditConnector)(implicit ec: ExecutionContext) {
   val auditSource = "ers-submissions"
 
   def sendEvent(transactionName : String, details: Map[String, String])(implicit hc: HeaderCarrier): Unit =

--- a/app/services/query/DataVerificationService.scala
+++ b/app/services/query/DataVerificationService.scala
@@ -23,10 +23,10 @@ import play.api.Logging
 import repositories.{DataVerificationMongoRepository, Repositories}
 
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class DataVerificationService @Inject()(applicationConfig: ApplicationConfig, repositories: Repositories) extends Logging {
+class DataVerificationService @Inject()(applicationConfig: ApplicationConfig,
+                                        repositories: Repositories)(implicit ec: ExecutionContext) extends Logging {
   lazy val dataVerificationRepository: DataVerificationMongoRepository = repositories.dataVerificationRepository
 
   def start: Future[Seq[ERSDataResults]] = {

--- a/app/services/query/MetaDataVerificationService.scala
+++ b/app/services/query/MetaDataVerificationService.scala
@@ -24,10 +24,10 @@ import org.joda.time.DateTime
 import play.api.Logging
 import repositories.{MetaDataVerificationMongoRepository, Repositories}
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
 
-class MetaDataVerificationService @Inject()(applicationConfig: ApplicationConfig, repositories: Repositories) extends Logging {
+class MetaDataVerificationService @Inject()(applicationConfig: ApplicationConfig,
+                                            repositories: Repositories)(implicit ec: ExecutionContext) extends Logging {
   lazy val metaDataVerificationRepository: MetaDataVerificationMongoRepository = repositories.metaDataVerificationRepository
 
   def start: Future[Seq[ERSMetaDataResults]] = {

--- a/app/services/resubmission/ResubPresubmissionService.scala
+++ b/app/services/resubmission/ResubPresubmissionService.scala
@@ -26,15 +26,15 @@ import uk.gov.hmrc.http.HeaderCarrier
 import utils.LoggingAndRexceptions.{ErsLoggingAndAuditing, ResubmissionExceptionEmitter}
 
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class ResubPresubmissionService @Inject()(metadataRepository: MetadataMongoRepository,
                                           val schedulerLoggingAndAuditing: ErsLoggingAndAuditing,
                                           submissionCommonService: SubmissionService,
                                           val applicationConfig: ApplicationConfig,
                                           auditEvents: AuditEvents,
-                                          resubmissionExceptionEmiter: ResubmissionExceptionEmitter) extends SchedulerConfig {
+                                          resubmissionExceptionEmiter: ResubmissionExceptionEmitter)
+                                         (implicit ec: ExecutionContext) extends SchedulerConfig {
 
   def processFailedSubmissions()(implicit request: Request[_], hc: HeaderCarrier): Future[Option[Boolean]] = {
     metadataRepository.findAndUpdateByStatus(

--- a/app/utils/CorrelationIDHelper.scala
+++ b/app/utils/CorrelationIDHelper.scala
@@ -34,7 +34,7 @@ trait CorrelationIdHelper {
                 HEADER_X_CORRELATION_ID,
                 UUID
                   .randomUUID()
-                  .toString()
+                  .toString
               ))
           case _ =>
             hcFromRequest

--- a/app/utils/SubmissionCommon.scala
+++ b/app/utils/SubmissionCommon.scala
@@ -46,10 +46,9 @@ class SubmissionCommon @Inject()(configUtils: ConfigUtils) extends Logging{
       )
     }
     catch {
-      case ex: Exception => {
-        logger.error(s"Error creating ObjectID from ${objectID}, exception: ${ex.getMessage}")
+      case ex: Exception =>
+        logger.error(s"Error creating ObjectID from $objectID, exception: ${ex.getMessage}")
         throw ex
-      }
     }
   }
 
@@ -73,14 +72,13 @@ class SubmissionCommon @Inject()(configUtils: ConfigUtils) extends Logging{
 
   def customFormat(value: DateTime, formatInfo: Config): String = {
     formatInfo.getString("type") match {
-      case "datetime" => {
+      case "datetime" =>
         val jsonFormat = formatInfo.getString("json_format")
         val jsonDateTimeFormat = new SimpleDateFormat(jsonFormat)
 
         jsonDateTimeFormat.format(
           value.toDate
         )
-      }
       case _ => value.toString()
     }
   }
@@ -117,16 +115,15 @@ class SubmissionCommon @Inject()(configUtils: ConfigUtils) extends Logging{
       val elemRow = row.getOrElse(configElem.getInt("row"))
       val value = fileData(elemRow)(elemColumn)
 
-      if (!value.isEmpty) {
+      if (value.nonEmpty) {
         val elemType: String = configElem.getString("type")
         val elemVal: JsValueWrapper = elemType match {
           case "string" => value
           case "int" => castToInt(value)
           case "double" => castToDouble(value)
-          case "boolean" => {
+          case "boolean" =>
             val valid_value = configElem.getString("valid_value")
-            (value.toUpperCase == valid_value.toUpperCase)
-          }
+            value.toUpperCase == valid_value.toUpperCase
         }
         getNewField(configElem, elemVal)
       }
@@ -147,7 +144,7 @@ class SubmissionCommon @Inject()(configUtils: ConfigUtils) extends Logging{
     }
     else {
       configUtils.extractField(configElem, metadata) match {
-        case None => {
+        case None =>
           if (configElem.hasPath("default_value")) {
             val elemType: String = configElem.getString("type")
             val elemVal: JsValueWrapper = if(elemType == "boolean") {
@@ -161,15 +158,13 @@ class SubmissionCommon @Inject()(configUtils: ConfigUtils) extends Logging{
           else {
             Json.obj()
           }
-        }
-        case value => {
+        case value =>
           val elemType: String = configElem.getString("type")
           val elemVal: JsValueWrapper = elemType match {
-            case "boolean" => {
+            case "boolean" =>
               val valid_value = configElem.getString("valid_value")
-              (value.toString == valid_value)
-            }
-            case "string" => {
+              value.toString == valid_value
+            case "string" =>
               value match {
                 case time: DateTime =>
                   customFormat(time, configElem.getConfig("format"))
@@ -178,30 +173,9 @@ class SubmissionCommon @Inject()(configUtils: ConfigUtils) extends Logging{
                 case _ =>
                   JsNull
               }
-            }
           }
           getNewField(configElem, elemVal)
-        }
       }
-    }
-  }
-
-  def updateSkipNext(oldSkipNext: Int, configData: Config, fileData: ListBuffer[Seq[String]], row: Option[Int] = None): Int = {
-    if (!configData.hasPath("skip_next")) {
-      return oldSkipNext
-    }
-
-    if(!configData.hasPath("skip_condition")) {
-      return configData.getInt("skip_next")
-    }
-
-    val column = configData.getInt("column")
-    val value = fileData(row.getOrElse(configData.getInt("row")))(column)
-    if (value.toUpperCase == configData.getString("skip_condition")) {
-      configData.getInt("skip_next")
-    }
-    else {
-      oldSkipNext
     }
   }
 
@@ -248,5 +222,4 @@ class SubmissionCommon @Inject()(configUtils: ConfigUtils) extends Logging{
       jsonField -> (getArrayFromJson(jsonField, oldJson) ++ getArrayFromJson(jsonField, newJson))
     )
   }
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(defaultSettings(): _*)
   .settings(
     targetJvm := "jvm-1.8",
-    scalaVersion := "2.12.17",
+    scalaVersion := "2.12.16",
     libraryDependencies ++= AppDependencies(),
     routesGenerator := InjectedRoutesGenerator
   )

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(defaultSettings(): _*)
   .settings(
     targetJvm := "jvm-1.8",
-    scalaVersion := "2.12.16",
+    scalaVersion := "2.12.17",
     libraryDependencies ++= AppDependencies(),
     routesGenerator := InjectedRoutesGenerator
   )
@@ -42,3 +42,6 @@ lazy val microservice = Project(appName, file("."))
 scalacOptions ++= Seq(
   "-P:silencer:pathFilters=views;routes"
 )
+
+addCommandAlias("scalastyleAll", "all scalastyle test:scalastyle")
+addCommandAlias("testAll", "all test it:test")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -43,6 +43,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
+play.modules.enabled += "config.ModuleBindings"
 
 # Session Timeout
 # ~~~~
@@ -224,6 +225,16 @@ scheduling {
   default-resubmit-start-date = 2016-04-01
   resubmit-start-date = 2016-04-01
   resubmit-end-date = 2017-06-02
+}
+
+schedules {
+    UpdateCreatedAtFieldJob {
+      enabled         = true
+      description     = "Update createdAt field in pre submission repository job"
+      expression      = "0_0/5_8-18_*_*_?" # run job every 5 minutes between 8-18
+      lockTimeout     = 10 # how long the repository should be locked for the job to complete in seconds (releases repo upon completion of the job or on timeout expiry)
+      updateLimit     = 2 # how many documents should be updated in single job run
+    }
 }
 
 ers-query{

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -260,5 +260,3 @@ csv {
   maxGroupSize = 10000
   submitParallelism = 2
 }
-
-logger.akka = INFO

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -228,13 +228,13 @@ scheduling {
 }
 
 schedules {
-    UpdateCreatedAtFieldJob {
-      enabled         = true
-      description     = "Update createdAt field in pre submission repository job"
-      expression      = "0_0/5_8-18_*_*_?" # run job every 5 minutes between 8-18
-      lockTimeout     = 10 # how long the repository should be locked for the job to complete in seconds (releases repo upon completion of the job or on timeout expiry)
-      updateLimit     = 2 # how many documents should be updated in single job run
-    }
+  update-created-at-field-job {
+    enabled         = true
+    description     = "Update createdAt field in pre submission repository job"
+    expression      = "0_*/5_8-18_*_*_?" # run job every 5 minutes between 8-18
+    lockTimeout     = 10 # how long the repository should be locked for the job to complete in seconds (releases repo upon completion of the job or on timeout expiry)
+    updateLimit     = 2 # how many documents should be updated in single job run
+  }
 }
 
 ers-query{
@@ -260,3 +260,5 @@ csv {
   maxGroupSize = 10000
   submitParallelism = 2
 }
+
+logger.akka = INFO

--- a/it/uk/gov/hmrc/PresubmissionMongoRepositorySpec.scala
+++ b/it/uk/gov/hmrc/PresubmissionMongoRepositorySpec.scala
@@ -22,10 +22,9 @@ import _root_.play.api.inject.guice.GuiceApplicationBuilder
 import _root_.play.api.libs.json.{JsObject, Json}
 import _root_.play.api.libs.ws.WSClient
 import _root_.play.api.test.Helpers._
-import models.UpdateRepositoryError
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatest.{BeforeAndAfterEach, EitherValues, Inside}
 import repositories.PresubmissionMongoRepository
 import scheduler.UpdateCreatedAtFieldsJob
 import services.DocumentUpdateService
@@ -33,8 +32,7 @@ import services.DocumentUpdateService
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ListBuffer
 
-class PresubmissionMongoRepositorySpec extends AnyWordSpecLike with Matchers
-  with BeforeAndAfterEach with EitherValues with Inside {
+class PresubmissionMongoRepositorySpec extends AnyWordSpecLike with Matchers with BeforeAndAfterEach {
 
   lazy val app: Application = new GuiceApplicationBuilder()
     .overrides(
@@ -131,13 +129,7 @@ class PresubmissionMongoRepositorySpec extends AnyWordSpecLike with Matchers
         presubmissionRepository.collection.insertOne(Json.toJsObject(Fixtures.schemeData)).toFuture()
       ).getInsertedId.asObjectId().getValue //document without createdAt
 
-      await(presubmissionRepository.addCreatedAtField(Seq(testDocumentId))).value.getModifiedCount shouldBe 1
-    }
-
-    "return an error if called with an empty list of ids" in {
-      inside(await(presubmissionRepository.addCreatedAtField(Seq.empty))) {
-        case Left(value) => value shouldBe UpdateRepositoryError("requirement failed: list of IDs for update cannot be empty")
-      }
+      await(presubmissionRepository.addCreatedAtField(Seq(testDocumentId))) shouldBe 1
     }
   }
 }

--- a/it/uk/gov/hmrc/UpdateCreatedAtFieldsJobISpec.scala
+++ b/it/uk/gov/hmrc/UpdateCreatedAtFieldsJobISpec.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc
+
+import _root_.play.api.Application
+import _root_.play.api.inject.guice.GuiceApplicationBuilder
+import _root_.play.api.libs.json.{JsObject, Json}
+import _root_.play.api.test.Helpers._
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import models.SchemeData
+import org.mongodb.scala.model.Filters
+import org.mongodb.scala.result.InsertOneResult
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import repositories.PresubmissionMongoRepository
+import scheduler.{ScheduledJob, UpdateCreatedAtFieldsJob}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class UpdateCreatedAtFieldsJobISpec extends AnyWordSpecLike
+  with Matchers
+  with GuiceOneServerPerSuite
+  with WiremockHelper
+  with BeforeAndAfterEach
+  with BeforeAndAfterAll {
+
+  override def beforeEach(): Unit = {
+    resetWiremock()
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    startWiremock()
+  }
+
+  override def afterAll(): Unit = {
+    stopWiremock()
+    super.afterAll()
+  }
+
+  override implicit lazy val app: Application = new GuiceApplicationBuilder()
+    .configure()
+    .build()
+
+  class Setup {
+    val repository: PresubmissionMongoRepository = app.injector.instanceOf[PresubmissionMongoRepository]
+    await(repository.collection.drop().toFuture())
+    await(repository.ensureIndexes)
+    await(repository.collection.countDocuments(Filters.empty()).toFuture()) shouldBe 0
+
+    def insert(schemeData: SchemeData): Boolean = await(repository.storeJson(schemeData))
+
+    def insertAsJson(schemeData: SchemeData): InsertOneResult = await(
+      repository.collection.insertOne(Json.toJsObject(schemeData)).toFuture())
+
+    def count: Long = await(repository.collection.countDocuments(Filters.empty).toFuture())
+
+    def getDocsWithCreatedAtField: Seq[JsObject] = await(repository.collection.find(Filters.and(Filters.exists("createdAt"), Filters.notEqual("createdAt", ""))).toFuture())
+  }
+
+  def getJob: ScheduledJob = app.injector.instanceOf[UpdateCreatedAtFieldsJob]
+
+  "UpdateCreatedAtFieldsJob" should {
+    "update the documents where the createdAt is missing" in new Setup {
+      insert(Fixtures.schemeData) //with createdAt
+      insertAsJson(Fixtures.schemeData) //without createdAt
+      insertAsJson(Fixtures.schemeData) //without createdAt
+
+      count shouldBe 3
+      getDocsWithCreatedAtField.size shouldBe 1
+
+      val updatedCount: Long = await(getJob.scheduledMessage.service.invoke.map(_.asInstanceOf[Long]))
+
+      updatedCount shouldBe 2
+      getDocsWithCreatedAtField.size shouldBe 3
+    }
+  }
+
+  "return updated count 0 if all documents have createdAt field" in new Setup {
+    insert(Fixtures.schemeData) //with createdAt
+    insert(Fixtures.schemeData) //with createdAt
+    insert(Fixtures.schemeData) //with createdAt
+
+    count shouldBe 3
+    getDocsWithCreatedAtField.size shouldBe 3
+
+    val updatedCount: Long = await(getJob.scheduledMessage.service.invoke.map(_.asInstanceOf[Long]))
+
+    updatedCount shouldBe 0
+  }
+}
+
+trait WiremockHelper {
+  val wiremockPort = 11111
+  val wiremockHost = "localhost"
+  val url = s"http://$wiremockHost:$wiremockPort"
+
+  lazy val wmConfig: WireMockConfiguration = wireMockConfig().port(wiremockPort)
+  lazy val wireMockServer = new WireMockServer(wmConfig)
+
+  def startWiremock(): Unit = {
+    wireMockServer.start()
+    WireMock.configureFor(wiremockHost, wiremockPort)
+  }
+
+  def stopWiremock(): Unit = wireMockServer.stop()
+
+  def resetWiremock(): Unit = WireMock.reset()
+}

--- a/it/uk/gov/hmrc/UpdateCreatedAtFieldsJobISpec.scala
+++ b/it/uk/gov/hmrc/UpdateCreatedAtFieldsJobISpec.scala
@@ -34,7 +34,7 @@ import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import repositories.PresubmissionMongoRepository
 import scheduler.{ScheduledJob, UpdateCreatedAtFieldsJob}
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 
 class UpdateCreatedAtFieldsJobISpec extends AnyWordSpecLike
   with Matchers
@@ -60,6 +60,8 @@ class UpdateCreatedAtFieldsJobISpec extends AnyWordSpecLike
   override implicit lazy val app: Application = new GuiceApplicationBuilder()
     .configure()
     .build()
+
+  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
 
   class Setup {
     val repository: PresubmissionMongoRepository = app.injector.instanceOf[PresubmissionMongoRepository]

--- a/it/uk/gov/hmrc/WiremockHelper.scala
+++ b/it/uk/gov/hmrc/WiremockHelper.scala
@@ -87,7 +87,7 @@ trait FakeErsStubService extends BeforeAndAfterAll with ScalaFutures {
 class FakeDocumentUpdateService extends DocumentUpdateService {
   override val jobName: String = "update-created-at-field-job"
 
-  override def invoke(implicit ec: ExecutionContext): Future[Long] = Future.successful(2)
+  override def invoke(implicit ec: ExecutionContext): Future[Boolean] = Future.successful(true)
 }
 
 class FakeUpdateCreatedAtFieldsJob @Inject()(

--- a/it/uk/gov/hmrc/WiremockHelper.scala
+++ b/it/uk/gov/hmrc/WiremockHelper.scala
@@ -85,7 +85,7 @@ trait FakeErsStubService extends BeforeAndAfterAll with ScalaFutures {
 }
 
 class FakeDocumentUpdateService extends DocumentUpdateService {
-  override val jobName: String = "UpdateCreatedAtFieldJob"
+  override val jobName: String = "update-created-at-field-job"
 
   override def invoke(implicit ec: ExecutionContext): Future[Long] = Future.successful(2)
 }
@@ -95,7 +95,7 @@ class FakeUpdateCreatedAtFieldsJob @Inject()(
                                               val service: FakeDocumentUpdateService,
                                               val applicationLifecycle: ApplicationLifecycle
                                             ) extends UpdateCreatedAtFieldsJob {
-  override def jobName: String = "UpdateCreatedAtFieldJob"
+  override def jobName: String = "update-created-at-field-job"
   override val scheduledMessage: SchedulingActor.ScheduledMessage[_] = UpdateDocumentsClass(service)
   override val actorSystem: ActorSystem = ActorSystem(jobName)
 }

--- a/it/uk/gov/hmrc/WiremockHelper.scala
+++ b/it/uk/gov/hmrc/WiremockHelper.scala
@@ -16,12 +16,21 @@
 
 package uk.gov.hmrc
 
+import _root_.play.api.Configuration
+import _root_.play.api.inject.ApplicationLifecycle
+import akka.actor.ActorSystem
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Suite}
+import scheduler.SchedulingActor.UpdateDocumentsClass
+import scheduler.{SchedulingActor, UpdateCreatedAtFieldsJob}
+import services.DocumentUpdateService
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
 
 trait FakeAuthService extends BeforeAndAfterAll with ScalaFutures {
   this: Suite =>
@@ -35,13 +44,13 @@ trait FakeAuthService extends BeforeAndAfterAll with ScalaFutures {
 
   lazy val downloadServer = new WireMockServer(wireMockConfig().port(19000))
 
-  override def beforeAll() = {
+  override def beforeAll(): Unit = {
     super.beforeAll()
     authServer.start()
     downloadServer.start()
   }
 
-  override def afterAll() = {
+  override def afterAll(): Unit = {
     super.afterAll()
     authServer.stop()
     downloadServer.stop()
@@ -73,4 +82,20 @@ trait FakeErsStubService extends BeforeAndAfterAll with ScalaFutures {
   }
 
   stubServer.stubFor(WireMock.post(urlMatching("/.*")).willReturn(WireMock.aResponse().withStatus(202)))
+}
+
+class FakeDocumentUpdateService extends DocumentUpdateService {
+  override val jobName: String = "UpdateCreatedAtFieldJob"
+
+  override def invoke(implicit ec: ExecutionContext): Future[Long] = Future.successful(2)
+}
+
+class FakeUpdateCreatedAtFieldsJob @Inject()(
+                                              val config: Configuration,
+                                              val service: FakeDocumentUpdateService,
+                                              val applicationLifecycle: ApplicationLifecycle
+                                            ) extends UpdateCreatedAtFieldsJob {
+  override def jobName: String = "UpdateCreatedAtFieldJob"
+  override val scheduledMessage: SchedulingActor.ScheduledMessage[_] = UpdateDocumentsClass(service)
+  override val actorSystem: ActorSystem = ActorSystem(jobName)
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,19 +4,19 @@ object AppDependencies {
   import play.core.PlayVersion
   import play.sbt.PlayImport._
 
-  private val silencerVersion = "1.7.9"
-  private val akkaVersion = "2.6.19"
+  private val silencerVersion = "1.7.12"
+  private val akkaVersion = "2.6.20"
 
   private val alpakkaVersion = "3.0.4"
-  private val nettyTransportVersion = "4.1.79.Final"
-  private val mongoVersion = "0.68.0"
+  private val nettyTransportVersion = "4.1.89.Final"
+  private val mongoVersion = "0.74.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc"        %% "bootstrap-backend-play-28"          % "6.4.0",
+    "uk.gov.hmrc"        %% "bootstrap-backend-play-28"          % "7.13.0",
     "uk.gov.hmrc"        %% "domain"                             % "8.1.0-play-28",
     "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-28"                 % mongoVersion,
-    "com.typesafe.play"  %% "play-json-joda"                     % "2.9.2",
+    "com.typesafe.play"  %% "play-json-joda"                     % "2.9.4",
     "io.netty"           %  "netty-transport-native-epoll"       % nettyTransportVersion,
     "com.lightbend.akka" %% "akka-stream-alpakka-csv"            % alpakkaVersion,
     "com.lightbend.akka" %% "akka-stream-alpakka-json-streaming" % alpakkaVersion,
@@ -25,7 +25,7 @@ object AppDependencies {
     "com.typesafe.akka"  %% "akka-protobuf"                      % akkaVersion,
     "com.typesafe.akka"  %% "akka-actor-typed"                   % akkaVersion,
     "com.typesafe.akka"  %% "akka-serialization-jackson"         % akkaVersion,
-    "com.typesafe.akka"  %% "akka-http-spray-json"               % "10.2.9",
+    "com.typesafe.akka"  %% "akka-http-spray-json"               % "10.2.10",
     "com.enragedginger"  %% "akka-quartz-scheduler"              % "1.9.3-akka-2.6.x",
     compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
     "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
@@ -37,9 +37,9 @@ object AppDependencies {
   }
 
   private val pegdownVersion = "1.6.0"
-  private val jsoupVersion = "1.15.2"
+  private val jsoupVersion = "1.15.4"
   private val scalaTestPlusPlayVersion = "5.1.0"
-  private val scalaTestVersion = "3.2.12"
+  private val scalaTestVersion = "3.2.15"
   private val mockitoCoreVersion = "4.6.1"
   private val flexmarkAllVersion = "0.62.2"
 
@@ -75,8 +75,7 @@ object AppDependencies {
         "org.jsoup"              %  "jsoup"                        % jsoupVersion             % scope,
         "io.netty"               %  "netty-transport-native-epoll" % nettyTransportVersion    % scope,
         "com.github.tomakehurst" %  "wiremock-jre8"                % "2.33.2"                 % scope,
-        "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.13.3"                 % scope,
-        "com.typesafe.akka"      %% "akka-testkit"            % akkaVersion              % scope
+        "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.13.5"                 % scope
       )
     }.test
   }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,6 +6,7 @@ object AppDependencies {
 
   private val silencerVersion = "1.7.12"
   private val akkaVersion = "2.6.20"
+  private val bootstrapVersion = "7.13.0"
 
   private val alpakkaVersion = "3.0.4"
   private val nettyTransportVersion = "4.1.89.Final"
@@ -13,7 +14,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc"        %% "bootstrap-backend-play-28"          % "7.13.0",
+    "uk.gov.hmrc"        %% "bootstrap-backend-play-28"          % bootstrapVersion,
     "uk.gov.hmrc"        %% "domain"                             % "8.1.0-play-28",
     "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-28"                 % mongoVersion,
     "com.typesafe.play"  %% "play-json-joda"                     % "2.9.4",
@@ -46,6 +47,7 @@ object AppDependencies {
   object Test {
     def apply(): Seq[ModuleID] = new TestDependencies {
       override lazy val test: Seq[ModuleID] = Seq(
+        "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % bootstrapVersion         % scope,
         "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28" % mongoVersion             % scope,
         "org.scalatest"          %% "scalatest"               % scalaTestVersion         % scope,
         "org.scalatestplus.play" %% "scalatestplus-play"      % scalaTestPlusPlayVersion % scope,
@@ -65,6 +67,7 @@ object AppDependencies {
       override lazy val scope: String = "it"
 
       override lazy val test: Seq[ModuleID] = Seq(
+        "uk.gov.hmrc"            %% "bootstrap-test-play-28"       % bootstrapVersion         % scope,
         "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"      % mongoVersion             % scope,
         "com.typesafe.play"      %% "play-test"                    % PlayVersion.current      % scope,
         "org.scalatest"          %% "scalatest"                    % scalaTestVersion         % scope,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,7 +11,7 @@ object AppDependencies {
   private val nettyTransportVersion = "4.1.79.Final"
   private val mongoVersion = "0.68.0"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc"        %% "bootstrap-backend-play-28"          % "6.4.0",
     "uk.gov.hmrc"        %% "domain"                             % "8.1.0-play-28",
@@ -26,6 +26,7 @@ object AppDependencies {
     "com.typesafe.akka"  %% "akka-actor-typed"                   % akkaVersion,
     "com.typesafe.akka"  %% "akka-serialization-jackson"         % akkaVersion,
     "com.typesafe.akka"  %% "akka-http-spray-json"               % "10.2.9",
+    "com.enragedginger"  %% "akka-quartz-scheduler"              % "1.9.3-akka-2.6.x",
     compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
     "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
   )
@@ -44,7 +45,7 @@ object AppDependencies {
 
   object Test {
     def apply(): Seq[ModuleID] = new TestDependencies {
-      override lazy val test = Seq(
+      override lazy val test: Seq[ModuleID] = Seq(
         "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28" % mongoVersion             % scope,
         "org.scalatest"          %% "scalatest"               % scalaTestVersion         % scope,
         "org.scalatestplus.play" %% "scalatestplus-play"      % scalaTestPlusPlayVersion % scope,
@@ -63,7 +64,7 @@ object AppDependencies {
 
       override lazy val scope: String = "it"
 
-      override lazy val test = Seq(
+      override lazy val test: Seq[ModuleID] = Seq(
         "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"      % mongoVersion             % scope,
         "com.typesafe.play"      %% "play-test"                    % PlayVersion.current      % scope,
         "org.scalatest"          %% "scalatest"                    % scalaTestVersion         % scope,
@@ -74,7 +75,8 @@ object AppDependencies {
         "org.jsoup"              %  "jsoup"                        % jsoupVersion             % scope,
         "io.netty"               %  "netty-transport-native-epoll" % nettyTransportVersion    % scope,
         "com.github.tomakehurst" %  "wiremock-jre8"                % "2.33.2"                 % scope,
-        "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.13.3"                 % scope
+        "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.13.3"                 % scope,
+        "com.typesafe.akka"      %% "akka-testkit"            % akkaVersion              % scope
       )
     }.test
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,4 +16,4 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sbt clean scalastyleAll compile coverage testAll coverageOff coverageReport dependencyUpdates

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,6 +1,6 @@
 <scalastyle>
     <name>Scalastyle standard configuration</name>
-    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
         <parameters>
             <parameter name="maxFileLength"><![CDATA[800]]></parameter>
@@ -25,9 +25,9 @@
  */]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
         <parameters>
             <parameter name="maxLineLength"><![CDATA[160]]></parameter>
@@ -49,7 +49,7 @@
             <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>
             <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
@@ -65,14 +65,14 @@
             <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
         <parameters>
             <parameter name="regex"><![CDATA[println]]></parameter>
@@ -88,8 +88,8 @@
             <parameter name="maximum"><![CDATA[10]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>
             <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
@@ -111,7 +111,7 @@
             <parameter name="maxMethods"><![CDATA[30]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="false"/>
+    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
 </scalastyle>

--- a/test/controllers/auth/AuthActionSpec.scala
+++ b/test/controllers/auth/AuthActionSpec.scala
@@ -44,7 +44,7 @@ class AuthActionSpec extends ERSTestHelper with BeforeAndAfterEach {
   def authAction(empRef: String): AuthAction = new AuthAction {
     override val optionalEmpRef: Option[EmpRef] = Try(EmpRef.fromIdentifiers(empRef)).toOption
     override def authConnector: AuthConnector = mockAuthConnector
-    override implicit val executionContext: ExecutionContext = ExecutionContext.global
+    override implicit val executionContext: ExecutionContext = ec
     override def parser: BodyParser[AnyContent] = mockBodyParser.default
   }
 

--- a/test/fixtures/WithMockedAuthActions.scala
+++ b/test/fixtures/WithMockedAuthActions.scala
@@ -30,7 +30,7 @@ trait WithMockedAuthActions {
 
   val mockAuthAction: AuthAction
 
-  def mockJsValueAuthAction: OngoingStubbing[Action[JsValue]] =
+  def mockJsValueAuthAction(implicit ec: ExecutionContext): OngoingStubbing[Action[JsValue]] =
     when(mockAuthAction.async(any[BodyParser[JsValue]])(any[Request[JsValue] => Future[Result]]()))
       .thenAnswer((invocation: InvocationOnMock) => {
         val passedInBodyParser = invocation.getArguments()(0).asInstanceOf[BodyParser[JsValue]]
@@ -40,7 +40,7 @@ trait WithMockedAuthActions {
 
           override def apply(request: Request[JsValue]): Future[Result] = passedInBlock(request)
 
-          override def executionContext: ExecutionContext = ExecutionContext.global
+          override def executionContext: ExecutionContext = ec
         }
       })
 }

--- a/test/helpers/ERSTestHelper.scala
+++ b/test/helpers/ERSTestHelper.scala
@@ -70,7 +70,7 @@ trait ERSTestHelper extends AnyWordSpecLike with Matchers with OptionValues with
 class FakeDocumentUpdateService extends DocumentUpdateService {
   override val jobName: String = "update-created-at-field-job"
 
-  override def invoke(implicit ec: ExecutionContext): Future[Long] = Future.successful(2)
+  override def invoke(implicit ec: ExecutionContext): Future[Boolean] = Future.successful(true)
 }
 
 class FakeUpdateCreatedAtFieldsJob @Inject()(

--- a/test/helpers/ERSTestHelper.scala
+++ b/test/helpers/ERSTestHelper.scala
@@ -49,7 +49,7 @@ trait ERSTestHelper extends AnyWordSpecLike with Matchers with OptionValues with
       .build()
 
   val mockCc: ControllerComponents = stubControllerComponents()
-  implicit def materializer: Materializer = Play.materializer(fakeApplication)
+  implicit def materializer: Materializer = Play.materializer(fakeApplication())
   implicit val ec: ExecutionContext = mockCc.executionContext
 
   def status(result: Future[Result]): Int = Await.result(result, 10.seconds).header.status

--- a/test/helpers/ERSTestHelper.scala
+++ b/test/helpers/ERSTestHelper.scala
@@ -68,7 +68,7 @@ trait ERSTestHelper extends AnyWordSpecLike with Matchers with OptionValues with
 }
 
 class FakeDocumentUpdateService extends DocumentUpdateService {
-  override val jobName: String = "UpdateCreatedAtFieldJob"
+  override val jobName: String = "update-created-at-field-job"
 
   override def invoke(implicit ec: ExecutionContext): Future[Long] = Future.successful(2)
 }
@@ -79,7 +79,7 @@ class FakeUpdateCreatedAtFieldsJob @Inject()(
                                               val applicationLifecycle: ApplicationLifecycle
 ) extends UpdateCreatedAtFieldsJob {
 
-  override def jobName: String = "UpdateCreatedAtFieldJob"
+  override def jobName: String = "update-created-at-field-job"
   override val scheduledMessage: SchedulingActor.ScheduledMessage[_] = UpdateDocumentsClass(service)
   override val actorSystem: ActorSystem = ActorSystem(jobName)
 }

--- a/test/helpers/ERSTestHelper.scala
+++ b/test/helpers/ERSTestHelper.scala
@@ -16,8 +16,7 @@
 
 package helpers
 
-import java.nio.charset.Charset
-
+import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.util.ByteString
 import org.scalatest.OptionValues
@@ -25,14 +24,29 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.Play
+import play.api.inject.ApplicationLifecycle
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{ControllerComponents, Result}
 import play.api.test.Helpers.stubControllerComponents
+import play.api.{Application, Configuration, Play, inject}
+import scheduler.SchedulingActor.UpdateDocumentsClass
+import scheduler.{SchedulingActor, UpdateCreatedAtFieldsJob}
+import services.DocumentUpdateService
 
+import java.nio.charset.Charset
+import javax.inject.Inject
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 trait ERSTestHelper extends AnyWordSpecLike with Matchers with OptionValues with MockitoSugar with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .overrides(
+        inject.bind[DocumentUpdateService].to[FakeDocumentUpdateService],
+        inject.bind[UpdateCreatedAtFieldsJob].to[FakeUpdateCreatedAtFieldsJob]
+      )
+      .build()
 
   val mockCc: ControllerComponents = stubControllerComponents()
   implicit def materializer: Materializer = Play.materializer(fakeApplication)
@@ -51,4 +65,21 @@ trait ERSTestHelper extends AnyWordSpecLike with Matchers with OptionValues with
 
   def await[T](future: Future[T], timeout: FiniteDuration = 10.seconds): T = Await.result(future, timeout)
 
+}
+
+class FakeDocumentUpdateService extends DocumentUpdateService {
+  override val jobName: String = "UpdateCreatedAtFieldJob"
+
+  override def invoke(implicit ec: ExecutionContext): Future[Long] = Future.successful(2)
+}
+
+class FakeUpdateCreatedAtFieldsJob @Inject()(
+                                              val config: Configuration,
+                                              val service: FakeDocumentUpdateService,
+                                              val applicationLifecycle: ApplicationLifecycle
+) extends UpdateCreatedAtFieldsJob {
+
+  override def jobName: String = "UpdateCreatedAtFieldJob"
+  override val scheduledMessage: SchedulingActor.ScheduledMessage[_] = UpdateDocumentsClass(service)
+  override val actorSystem: ActorSystem = ActorSystem(jobName)
 }

--- a/test/scheduler/ScheduledJobSpec.scala
+++ b/test/scheduler/ScheduledJobSpec.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scheduler
+
+import akka.actor.ActorSystem
+import com.typesafe.akka.extension.quartz.QuartzSchedulerExtension
+import org.mockito.Mockito.reset
+import org.quartz.CronExpression
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
+import play.api.inject.ApplicationLifecycle
+import scheduler.SchedulingActor.UpdateDocumentsClass
+import services.DocumentUpdateService
+class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
+  val jobNameTest = "testJobName"
+  val mockActorSystem: ActorSystem = mock[ActorSystem]
+  val mockService: DocumentUpdateService = mock[DocumentUpdateService]
+  val mockApplicationLifecycle: ApplicationLifecycle = mock[ApplicationLifecycle]
+
+  val mockQuartzSchedulerExtension: QuartzSchedulerExtension = mock[QuartzSchedulerExtension]
+
+  class Setup(cronString: String, enabled: Boolean = false) {
+    val testConfig: Configuration = Configuration(
+      s"schedules.$jobNameTest.expression" -> s"$cronString",
+      s"schedules.$jobNameTest.enabled" -> enabled,
+      s"schedules.$jobNameTest.description" -> "testDescription"
+    )
+
+    reset(
+      mockQuartzSchedulerExtension,
+      mockService,
+      mockActorSystem)
+
+    val job: ScheduledJob = new ScheduledJob {
+      override lazy val scheduledMessage: SchedulingActor.ScheduledMessage[_] = UpdateDocumentsClass(mockService)
+      override val config: Configuration = testConfig
+      override lazy val actorSystem: ActorSystem = mockActorSystem
+      override lazy val jobName: String = jobNameTest
+      override lazy val scheduler: QuartzSchedulerExtension = mockQuartzSchedulerExtension
+    }
+  }
+
+  "expression should read from string correctly with underscores" in new Setup("0_0/10_0-23_?_*_*_*") {
+    job.expression shouldBe "0 0/10 0-23 ? * * *"
+  }
+
+  "expression should read from string correctly with underscores with a different value we will also be using" in new Setup("0/59_0_0-23_?_*_*_*") {
+    job.expression shouldBe "0/59 0 0-23 ? * * *"
+  }
+
+  "isValid should return true if valid cron config returned" in new Setup("0_0/2_0-23_?_*_*_*") {
+    job.isValid shouldBe true
+  }
+
+  "isValid should return false if an invalid cron config is returned" in new Setup("testInvalidCronString") {
+    job.isValid shouldBe false
+  }
+
+  "isValid should return false if empty string is returned" in new Setup("") {
+    job.isValid shouldBe false
+  }
+
+  "expression once converted should convert to a cron expression success" in new Setup("0/10_0_0-23_?_*_*_*") {
+    val parsed = new CronExpression(job.expression)
+    parsed.getCronExpression shouldBe "0/10 0 0-23 ? * * *"
+    parsed.getExpressionSummary shouldBe
+      """seconds: 0,10,20,30,40,50
+        |minutes: 0
+        |hours: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23
+        |daysOfMonth: ?
+        |months: *
+        |daysOfWeek: *
+        |lastdayOfWeek: false
+        |nearestWeekday: false
+        |NthDayOfWeek: 0
+        |lastdayOfMonth: false
+        |years: *
+        |""".stripMargin
+  }
+
+  //run job every 5 minutes between 8-18
+  "expression for local dev once converted should convert to a cron expression success" in new Setup("0_0/5_8-18_*_*_?") {
+    val parsed = new CronExpression(job.expression)
+    parsed.getCronExpression shouldBe "0 0/5 8-18 * * ?"
+    parsed.getExpressionSummary shouldBe
+      """seconds: 0
+        |minutes: 0,5,10,15,20,25,30,35,40,45,50,55
+        |hours: 8,9,10,11,12,13,14,15,16,17,18
+        |daysOfMonth: *
+        |months: *
+        |daysOfWeek: ?
+        |lastdayOfWeek: false
+        |nearestWeekday: false
+        |NthDayOfWeek: 0
+        |lastdayOfMonth: false
+        |years: *
+        |""".stripMargin
+  }
+
+  //run job every 10 minutes between 8-18
+  "expression for QA once converted should convert to a cron expression success" in new Setup("0_0/10_8-18_*_*_?") {
+    val parsed = new CronExpression(job.expression)
+    parsed.getCronExpression shouldBe "0 0/10 8-18 * * ?"
+    parsed.getExpressionSummary shouldBe
+      """seconds: 0
+        |minutes: 0,10,20,30,40,50
+        |hours: 8,9,10,11,12,13,14,15,16,17,18
+        |daysOfMonth: *
+        |months: *
+        |daysOfWeek: ?
+        |lastdayOfWeek: false
+        |nearestWeekday: false
+        |NthDayOfWeek: 0
+        |lastdayOfMonth: false
+        |years: *
+        |""".stripMargin
+  }
+
+  //run job every 10 minutes between 18-8
+  "expression for Staging/Prod once converted should convert to a cron expression success" in new Setup("0_0/10_18-8_*_*_?") {
+    val parsed = new CronExpression(job.expression)
+    parsed.getCronExpression shouldBe "0 0/10 18-8 * * ?"
+    parsed.getExpressionSummary shouldBe
+      """seconds: 0
+        |minutes: 0,10,20,30,40,50
+        |hours: 0,1,2,3,4,5,6,7,8,18,19,20,21,22,23
+        |daysOfMonth: *
+        |months: *
+        |daysOfWeek: ?
+        |lastdayOfWeek: false
+        |nearestWeekday: false
+        |NthDayOfWeek: 0
+        |lastdayOfMonth: false
+        |years: *
+        |""".stripMargin
+  }
+
+  "scheduler called if enabled and valid cron config" in new Setup("0/10_0_0-23_?_*_*_*", true) {
+    job.schedule shouldBe true
+  }
+
+  "scheduler NOT called if not enabled and cron config invalid" in new Setup("testInvalidCronString", false) {
+    job.schedule shouldBe false
+
+  }
+  "scheduler NOT called if enabled and cron config invalid" in new Setup("testInvalidCronString", true) {
+    job.schedule shouldBe false
+  }
+}

--- a/test/scheduler/ScheduledJobSpec.scala
+++ b/test/scheduler/ScheduledJobSpec.scala
@@ -27,12 +27,12 @@ import play.api.Configuration
 import play.api.inject.ApplicationLifecycle
 import scheduler.SchedulingActor.UpdateDocumentsClass
 import services.DocumentUpdateService
+
 class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
   val jobNameTest = "testJobName"
   val mockActorSystem: ActorSystem = mock[ActorSystem]
   val mockService: DocumentUpdateService = mock[DocumentUpdateService]
   val mockApplicationLifecycle: ApplicationLifecycle = mock[ApplicationLifecycle]
-
   val mockQuartzSchedulerExtension: QuartzSchedulerExtension = mock[QuartzSchedulerExtension]
 
   class Setup(cronString: String, enabled: Boolean = false) {
@@ -60,10 +60,6 @@ class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
     job.expression shouldBe "0 0/10 0-23 ? * * *"
   }
 
-  "expression should read from string correctly with underscores with a different value we will also be using" in new Setup("0/59_0_0-23_?_*_*_*") {
-    job.expression shouldBe "0/59 0 0-23 ? * * *"
-  }
-
   "isValid should return true if valid cron config returned" in new Setup("0_0/2_0-23_?_*_*_*") {
     job.isValid shouldBe true
   }
@@ -76,6 +72,7 @@ class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
     job.isValid shouldBe false
   }
 
+  //run job every 10 seconds every hour
   "expression once converted should convert to a cron expression success" in new Setup("0/10_0_0-23_?_*_*_*") {
     val parsed = new CronExpression(job.expression)
     parsed.getCronExpression shouldBe "0/10 0 0-23 ? * * *"
@@ -157,8 +154,8 @@ class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
 
   "scheduler NOT called if not enabled and cron config invalid" in new Setup("testInvalidCronString", false) {
     job.schedule shouldBe false
-
   }
+
   "scheduler NOT called if enabled and cron config invalid" in new Setup("testInvalidCronString", true) {
     job.schedule shouldBe false
   }

--- a/test/scheduler/ScheduledJobSpec.scala
+++ b/test/scheduler/ScheduledJobSpec.scala
@@ -56,11 +56,11 @@ class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
     }
   }
 
-  "expression should read from string correctly with underscores" in new Setup("0_0/10_0-23_?_*_*_*") {
-    job.expression shouldBe "0 0/10 0-23 ? * * *"
+  "expression should read from string correctly with underscores" in new Setup("0_*/10_0-23_?_*_*_*") {
+    job.expression shouldBe "0 */10 0-23 ? * * *"
   }
 
-  "isValid should return true if valid cron config returned" in new Setup("0_0/2_0-23_?_*_*_*") {
+  "isValid should return true if valid cron config returned" in new Setup("0_*/2_0-23_?_*_*_*") {
     job.isValid shouldBe true
   }
 
@@ -73,9 +73,9 @@ class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
   }
 
   //run job every 10 seconds every hour
-  "expression once converted should convert to a cron expression success" in new Setup("0/10_0_0-23_?_*_*_*") {
+  "expression once converted should convert to a cron expression success" in new Setup("*/10_0_0-23_?_*_*_*") {
     val parsed = new CronExpression(job.expression)
-    parsed.getCronExpression shouldBe "0/10 0 0-23 ? * * *"
+    parsed.getCronExpression shouldBe "*/10 0 0-23 ? * * *"
     parsed.getExpressionSummary shouldBe
       """seconds: 0,10,20,30,40,50
         |minutes: 0
@@ -92,9 +92,9 @@ class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
   }
 
   //run job every 5 minutes between 8-18
-  "expression for local dev once converted should convert to a cron expression success" in new Setup("0_0/5_8-18_*_*_?") {
+  "expression for local dev once converted should convert to a cron expression success" in new Setup("0_*/5_8-18_*_*_?") {
     val parsed = new CronExpression(job.expression)
-    parsed.getCronExpression shouldBe "0 0/5 8-18 * * ?"
+    parsed.getCronExpression shouldBe "0 */5 8-18 * * ?"
     parsed.getExpressionSummary shouldBe
       """seconds: 0
         |minutes: 0,5,10,15,20,25,30,35,40,45,50,55
@@ -110,13 +110,13 @@ class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
         |""".stripMargin
   }
 
-  //run job every 10 minutes between 8-18
-  "expression for QA once converted should convert to a cron expression success" in new Setup("0_0/10_8-18_*_*_?") {
+  //run job every 5 minutes between 8-18
+  "expression for QA once converted should convert to a cron expression success" in new Setup("0_*/5_8-18_*_*_?") {
     val parsed = new CronExpression(job.expression)
-    parsed.getCronExpression shouldBe "0 0/10 8-18 * * ?"
+    parsed.getCronExpression shouldBe "0 */5 8-18 * * ?"
     parsed.getExpressionSummary shouldBe
       """seconds: 0
-        |minutes: 0,10,20,30,40,50
+        |minutes: 0,5,10,15,20,25,30,35,40,45,50,55
         |hours: 8,9,10,11,12,13,14,15,16,17,18
         |daysOfMonth: *
         |months: *
@@ -130,9 +130,9 @@ class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
   }
 
   //run job every 10 minutes between 18-8
-  "expression for Staging/Prod once converted should convert to a cron expression success" in new Setup("0_0/10_18-8_*_*_?") {
+  "expression for Staging/Prod once converted should convert to a cron expression success" in new Setup("0_*/10_18-23,0-8_*_*_?") {
     val parsed = new CronExpression(job.expression)
-    parsed.getCronExpression shouldBe "0 0/10 18-8 * * ?"
+    parsed.getCronExpression shouldBe "0 */10 18-23,0-8 * * ?"
     parsed.getExpressionSummary shouldBe
       """seconds: 0
         |minutes: 0,10,20,30,40,50
@@ -148,7 +148,7 @@ class ScheduledJobSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
         |""".stripMargin
   }
 
-  "scheduler called if enabled and valid cron config" in new Setup("0/10_0_0-23_?_*_*_*", true) {
+  "scheduler called if enabled and valid cron config" in new Setup("*/10_0_0-23_?_*_*_*", true) {
     job.schedule shouldBe true
   }
 

--- a/test/services/DocumentUpdateServiceSpec.scala
+++ b/test/services/DocumentUpdateServiceSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import com.mongodb.client.result.UpdateResult
+import helpers.ERSTestHelper
+import models.{UpdateRequestAcknowledged, UpdateRequestAcknowledgedNothingToUpdate, UpdateRequestNotAcknowledged}
+import org.bson.types.ObjectId
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, times, verify, when}
+import org.scalatest.BeforeAndAfterEach
+import repositories.{LockRepositoryProvider, PresubmissionMongoRepository}
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import scala.concurrent.Await.result
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+class DocumentUpdateServiceSpec extends ERSTestHelper with BeforeAndAfterEach {
+
+  val mockPresubmissionMongo: PresubmissionMongoRepository = mock[PresubmissionMongoRepository]
+  val mockLockKeeper: LockRepositoryProvider = mock[LockRepositoryProvider]
+  val mockServicesConfig: ServicesConfig = mock[ServicesConfig]
+
+  class Setup() {
+    val documentUpdateService: DefaultDocumentUpdateService = new DefaultDocumentUpdateService(
+      mockPresubmissionMongo,
+      mockLockKeeper,
+      mockServicesConfig
+    )
+  }
+
+  val successfulUpdateResult: UpdateResult = UpdateResult.acknowledged(0, 2, null)
+  val successfulUpdateResultNoModified: UpdateResult = UpdateResult.acknowledged(0, 0, null)
+
+  override def beforeEach(): Unit = {
+    reset(mockPresubmissionMongo)
+    reset(mockLockKeeper)
+    reset(mockServicesConfig)
+  }
+
+  "updateMissingCreatedAtFields" should {
+    "run the update document scheduler job and return successful update result with modified count != 0" when {
+      "there are documents without createdAt fields" in new Setup {
+        when(mockPresubmissionMongo.getDocumentIdsWithoutCreatedAtField(any()))
+          .thenReturn(Future.successful(Seq(ObjectId.get(), ObjectId.get())))
+        when(mockPresubmissionMongo.addCreatedAtField(any()))
+          .thenReturn(Future.successful(Right(successfulUpdateResult)))
+
+        val (modifiedDocuments, updateMessage) = result(documentUpdateService.updateMissingCreatedAtFields(), Duration.Inf)
+
+        modifiedDocuments shouldBe 2
+        updateMessage shouldBe UpdateRequestAcknowledged(2)
+
+        verify(mockPresubmissionMongo, times(1)).getDocumentIdsWithoutCreatedAtField(any[Int])
+        verify(mockPresubmissionMongo, times(1)).addCreatedAtField(any[Seq[ObjectId]])
+      }
+    }
+
+    "run the update document scheduler job and return successful update result with modified count == 0" when {
+      "there are no documents without createdAt fields" in new Setup {
+        when(mockPresubmissionMongo.getDocumentIdsWithoutCreatedAtField(any()))
+          .thenReturn(Future.successful(Seq()))
+        when(mockPresubmissionMongo.addCreatedAtField(any()))
+          .thenReturn(Future.successful(Right(successfulUpdateResultNoModified)))
+
+        val (modifiedDocuments, updateMessage) = result(documentUpdateService.updateMissingCreatedAtFields(), Duration.Inf)
+
+        modifiedDocuments shouldBe 0
+        updateMessage shouldBe UpdateRequestAcknowledgedNothingToUpdate
+
+        verify(mockPresubmissionMongo, times(1)).getDocumentIdsWithoutCreatedAtField(any[Int])
+        verify(mockPresubmissionMongo, times(0)).addCreatedAtField(any[Seq[ObjectId]])
+      }
+    }
+
+    "run the update document scheduler job and return failed result" when {
+      "the update was not acknowledged" in new Setup {
+        when(mockPresubmissionMongo.getDocumentIdsWithoutCreatedAtField(any()))
+          .thenReturn(Future.successful(Seq(ObjectId.get())))
+        when(mockPresubmissionMongo.addCreatedAtField(any()))
+          .thenReturn(Future.successful(Left(UpdateRequestNotAcknowledged)))
+
+        val (modifiedDocuments, updateMessage) = result(documentUpdateService.updateMissingCreatedAtFields(), Duration.Inf)
+
+        modifiedDocuments shouldBe 0
+        updateMessage shouldBe UpdateRequestNotAcknowledged
+
+        verify(mockPresubmissionMongo, times(1)).getDocumentIdsWithoutCreatedAtField(any[Int])
+        verify(mockPresubmissionMongo, times(1)).addCreatedAtField(any[Seq[ObjectId]])
+      }
+    }
+  }
+}

--- a/test/services/DocumentUpdateServiceSpec.scala
+++ b/test/services/DocumentUpdateServiceSpec.scala
@@ -18,7 +18,7 @@ package services
 
 import com.mongodb.client.result.UpdateResult
 import helpers.ERSTestHelper
-import models.{UpdateRequestAcknowledged, UpdateRequestAcknowledgedNothingToUpdate, UpdateRequestNotAcknowledged}
+import models.{UpdateRequestAcknowledged, UpdateRequestNothingToUpdate, UpdateRequestNotAcknowledged}
 import org.bson.types.ObjectId
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -81,7 +81,7 @@ class DocumentUpdateServiceSpec extends ERSTestHelper with BeforeAndAfterEach {
         val (modifiedDocuments, updateMessage) = result(documentUpdateService.updateMissingCreatedAtFields(), Duration.Inf)
 
         modifiedDocuments shouldBe 0
-        updateMessage shouldBe UpdateRequestAcknowledgedNothingToUpdate
+        updateMessage shouldBe UpdateRequestNothingToUpdate
 
         verify(mockPresubmissionMongo, times(1)).getDocumentIdsWithoutCreatedAtField(any[Int])
         verify(mockPresubmissionMongo, times(0)).addCreatedAtField(any[Seq[ObjectId]])

--- a/test/services/PresubmissionServiceSpec.scala
+++ b/test/services/PresubmissionServiceSpec.scala
@@ -162,5 +162,4 @@ class PresubmissionServiceSpec extends ERSTestHelper {
       result shouldBe false
     }
   }
-
 }

--- a/test/services/audit/AuditServiceTest.scala
+++ b/test/services/audit/AuditServiceTest.scala
@@ -20,17 +20,12 @@ import helpers.ERSTestHelper
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
 import org.mockito.internal.verification.VerificationModeFactory
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.mvc.AnyContent
 import play.api.test.FakeRequest
 import services.audit.AuditService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.DataEvent
-
-import scala.concurrent.ExecutionContext
 
 class AuditServiceTest extends ERSTestHelper {
 

--- a/test/services/audit/AuditServiceTest.scala
+++ b/test/services/audit/AuditServiceTest.scala
@@ -16,6 +16,7 @@
 
 package services
 
+import helpers.ERSTestHelper
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
 import org.mockito.internal.verification.VerificationModeFactory
@@ -29,7 +30,9 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.DataEvent
 
-class AuditServiceTest extends AnyWordSpecLike with Matchers with MockitoSugar {
+import scala.concurrent.ExecutionContext
+
+class AuditServiceTest extends ERSTestHelper {
 
   implicit val request: FakeRequest[AnyContent] = FakeRequest()
   implicit val hc: HeaderCarrier = new HeaderCarrier


### PR DESCRIPTION
# DDCE-3746


**TO BE MERGED AFTER CONFIGURATION**

Summary of changes:
- added scheduler
- added service that will add createdAt to the documents without it
- added configuration
- added tests
- updated dependencies
- done cleanups

Scheduler starts when enabled and valid cron expression supplied. Job performs updates in batches specified by limit. If there is no documents without createdAt update is not tried.

Mongo takes care of removing expired documents.  
