### PR TITLE
Ddce-4329

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -26,6 +26,7 @@ class ApplicationConfig @Inject()(serviceConfig: ServicesConfig) {
 
   lazy val presubmissionCollection: String = serviceConfig.getString("settings.presubmission-collection")
   lazy val presubmissionCollectionTTL: Int = serviceConfig.getInt("settings.presubmission-collection-ttl-days")
+  lazy val presubmissionCollectionIndexReplace: Boolean = serviceConfig.getBoolean("settings.presubmission-collection-index-replace")
   lazy val metadataCollection: String = serviceConfig.getString("settings.metadata-collection")
   lazy val uploadCsvSizeLimit: Int = serviceConfig.getInt("csv.uploadSizeLimit")
   lazy val maxGroupSize: Int = serviceConfig.getInt("csv.maxGroupSize")

--- a/app/repositories/PresubmissionMongoRepository.scala
+++ b/app/repositories/PresubmissionMongoRepository.scala
@@ -50,7 +50,7 @@ class PresubmissionMongoRepository @Inject()(applicationConfig: ApplicationConfi
           .expireAfter(applicationConfig.presubmissionCollectionTTL, TimeUnit.DAYS)
       )
     ),
-    replaceIndexes = true
+    replaceIndexes = applicationConfig.presubmissionCollectionIndexReplace
   ) with Logging {
 
   private val objectIdKey: String = "_id"

--- a/app/repositories/PresubmissionMongoRepository.scala
+++ b/app/repositories/PresubmissionMongoRepository.scala
@@ -49,7 +49,8 @@ class PresubmissionMongoRepository @Inject()(applicationConfig: ApplicationConfi
       IndexModel(ascending("createdAt"), indexOptions = IndexOptions().name("timeToLive")
           .expireAfter(applicationConfig.presubmissionCollectionTTL, TimeUnit.DAYS)
       )
-    )
+    ),
+    replaceIndexes = true
   ) with Logging {
 
   private val objectIdKey: String = "_id"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -237,7 +237,7 @@ ers-query{
 
 settings {
   presubmission-collection = "ers-presubmission"
-  presubmission-collection-ttl-days = 365
+  presubmission-collection-ttl-days = 548
   metadata-collection = "ers-metadata"
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -238,6 +238,7 @@ ers-query{
 settings {
   presubmission-collection = "ers-presubmission"
   presubmission-collection-ttl-days = 548
+  presubmission-collection-index-replace = true
   metadata-collection = "ers-metadata"
 }
 


### PR DESCRIPTION
# DDCE-4329

- Update TTL index for `ers-submissions.ers-presubmission` collection from `365 (12 months)` -> `548 (18 months)`.
- Added flag to config to make index replacement configurable through config

## Testing
#### Check submission with updated TTL config rewrites index
- Submission completed using frontend with TTL unchanged
- Checked index created in local mongo DB (365 days)
```
"name" : "timeToLive",
"ns" : "ers-submissions.ers-presubmission",
"expireAfterSeconds" : NumberLong(31536000)
```
- Updated config, setting `presubmission-collection-ttl-days = 548` and `presubmission-collection-index-replace = true`
- Submitted a second submissions using frontend
- Log line indicated ttl index would be rewritted: `... Conflicting Mongo index found. Index 'timeToLive' in ers-submissions.ers-presubmission will be recreated ...`
- Checked index created in local mongo DB (548 days)
```
"name" : "timeToLive",
"ns" : "ers-submissions.ers-presubmission",
"expireAfterSeconds" : NumberLong(47347200)
```
#### Check submission after TTL index rewritten 
- Set `presubmission-collection-index-replace = false` in config
- Submission completed using frontend successfully 

#### Update `createdAt` field for records to check index works correctly 
- 12/06/2023 (today) - 548 days = 11/12/2021
- Update `createdAt` field to 12/12/2021 -> Not deleted  
- Update `createdAt` field to 11/12/2021 -> Deleted  

