### PR TITLE
DDCE-4346: Improve config and separate integration tests

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -37,14 +37,12 @@ class ApplicationConfig @Inject()(serviceConfig: ServicesConfig) {
   lazy val UrlHeaderEnvironment: String = serviceConfig.getString("microservice.services.ers-stub.environment")
   lazy val UrlHeaderAuthorization: String = s"Bearer ${serviceConfig.getString("microservice.services.ers-stub.authorization-token")}"
 
-  lazy val schedulerStatuses: List[String] = Try(serviceConfig.getString("schedules.resubmission-service.statuses").split(",").toList).getOrElse(List())
-
   lazy val schedulerSchemeRefListEnabled: Boolean = serviceConfig.getBoolean("schedules.resubmission-service.schemaRefsFilter.enabled")
   lazy val schedulerSchemeRefList: List[String] = Try(serviceConfig.getString("schedules.resubmission-service.schemaRefsFilter.filter").split(",").toList)
     .getOrElse(List())
   lazy val schedulerSchemeRefStatusList: List[String] = Try(serviceConfig.getString("schedules.resubmission-service.resubmit-list-statuses").split(",").toList)
     .getOrElse(List())
-  lazy val schedulerSchemeRefFailStatus: String = serviceConfig.getString("schedules.resubmission-service.resubmit-list-failStatus")
+  lazy val schedulerSchemeRefFailStatus: String = serviceConfig.getString("schedules.resubmission-service.resubmit-fail-status")
 
   lazy val schedulerEnableResubmitByScheme: Boolean = serviceConfig.getBoolean("schedules.resubmission-service.schemaFilter.enabled")
   lazy val schedulerResubmitScheme: String = serviceConfig.getString("schedules.resubmission-service.schemaFilter.filter")

--- a/app/models/Statuses.scala
+++ b/app/models/Statuses.scala
@@ -21,6 +21,5 @@ object Statuses extends Enumeration {
   val Saved = Value("saved")
   val Sent = Value("sent")
   val Failed = Value("failed")
-  val FailedScheduler = Value("failedScheduler")
   val Process = Value("process")
 }

--- a/app/services/resubmission/SchedulerConfig.scala
+++ b/app/services/resubmission/SchedulerConfig.scala
@@ -22,17 +22,9 @@ import models.Statuses
 trait SchedulerConfig {
   val applicationConfig: ApplicationConfig
 
-  val failedStatus: String = if (applicationConfig.schedulerSchemeRefListEnabled) {
-    applicationConfig.schedulerSchemeRefFailStatus
-  } else {
-    Statuses.FailedScheduler.toString
-  }
+  val failedStatus: String = applicationConfig.schedulerSchemeRefFailStatus
 
-  val searchStatusList: List[String] = if (applicationConfig.schedulerSchemeRefListEnabled) {
-    applicationConfig.schedulerSchemeRefStatusList
-  } else {
-    applicationConfig.schedulerStatuses
-  }
+  val searchStatusList: List[String] = applicationConfig.schedulerSchemeRefStatusList
 
   val schemeRefList: Option[List[String]] = if (applicationConfig.schedulerSchemeRefListEnabled) {
     Some(applicationConfig.schedulerSchemeRefList)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -181,12 +181,10 @@ schedules {
       lockTimeout           = 10 # how long the repository should be locked for the job to complete in seconds (releases repo upon completion of the job or on timeout expiry)
       resubmissionLimit     = 10 # how many resubmissions should be processed in a job run
       resubmit-list-statuses = "saved,failed,largefiles,sent,successResubmit,failedResubmission"
-      resubmit-list-failStatus = failedResubmission
+      resubmit-fail-status = failedResubmission
       resubmit-successful-status = successResubmit
-      statuses = failed
-      default-resubmit-start-date = 2016-04-01
       dateTimeFilter {
-        enabled = true # indicates if dateFilter should be applied (true - records will only be resubmitted if metaData.schemaInfo.timestamp is after `dateToFilterOn`)
+        enabled = false # indicates if dateFilter should be applied (true - records will only be resubmitted if metaData.schemaInfo.timestamp is after `dateToFilterOn`)
         filter = "1/5/2023"
       }
       schemaRefsFilter {
@@ -194,18 +192,12 @@ schedules {
         filter = "XE1100000000000,XZ1100000000000,XD1100000000000,XK1100000000000,XB1100000000000"
       }
       schemaFilter {
-        enabled = true
+        enabled = false
         filter = "CSOP"
       }
     }
 }
 
-ers-query{
-  enabled = true
-  schemetype=SAYE
-  start-date=2016-04-01
-  end-date=2017-06-02
-}
 
 settings {
   presubmission-collection = "ers-presubmission"

--- a/it/uk/gov/hmrc/Fixtures.scala
+++ b/it/uk/gov/hmrc/Fixtures.scala
@@ -27,8 +27,10 @@ import scala.util.Random
 object Fixtures {
   val invalidPayload: JsObject = Json.obj("invalid data" -> "test")
 
-  def schemeInfo(schemaType: String = "EMI", timestamp: DateTime = DateTime.now(DateTimeZone.UTC)): SchemeInfo = SchemeInfo (
-    schemeRef = "XA1100000000000",
+  def schemeInfo(schemaType: String = "EMI",
+                 timestamp: DateTime = DateTime.now(DateTimeZone.UTC),
+                 schemeRef: String = "XA1100000000000"): SchemeInfo = SchemeInfo (
+    schemeRef = schemeRef,
     timestamp = timestamp,
     schemeId = "123PA12345678",
     taxYear = "2014/15",
@@ -45,8 +47,8 @@ object Fixtures {
   )
   def submissionsSchemeDataJson(submissionsSchemeData: SubmissionsSchemeData): JsObject = Json.toJson(submissionsSchemeData).as[JsObject]
 
-  def ersMetaData(schemaType: String, timestamp: DateTime): ErsMetaData = ErsMetaData(
-    schemeInfo = schemeInfo(schemaType, timestamp),
+  def ersMetaData(schemaType: String, timestamp: DateTime, schemeRef: String): ErsMetaData = ErsMetaData(
+    schemeInfo = schemeInfo(schemaType, timestamp, schemeRef),
     ipRef = "127.0.0.0",
     aoRef = Some("123PA12345678"),
     empRef = "EMI - MyScheme - XA1100000000000 - 2014/15",
@@ -85,12 +87,13 @@ object Fixtures {
                       transferStatus: Option[String] = Some("saved"),
                       schemaType: String = "EMI",
                       bundleRef: String = "testbundle",
-                      timestamp: DateTime = DateTime.now(DateTimeZone.UTC)): ErsSummary = ErsSummary(
+                      timestamp: DateTime = DateTime.now(DateTimeZone.UTC),
+                      schemeRef: String = "XA1100000000000"): ErsSummary = ErsSummary(
     bundleRef = bundleRef,
     isNilReturn = if(isNilReturn) "2" else "1",
     fileType = Some("ods"),
     confirmationDateTime = DateTime.now(DateTimeZone.UTC),
-    metaData = ersMetaData(schemaType, timestamp),
+    metaData = ersMetaData(schemaType, timestamp, schemeRef),
     altAmendsActivity = None,
     alterationAmends = None,
     groupService = Some(
@@ -134,19 +137,15 @@ object Fixtures {
   def generateListOfErsSummaries(): Seq[ErsSummary] = {
 
     val failedJobs: Seq[ErsSummary] = generateListOfErsSummaries(
-      numberRecords = 20
+      numberRecords = 10
     )
 
-    val failedJobsWithWrongSchema: Seq[ErsSummary] = generateListOfErsSummaries(
-      numberRecords = 10,
-      schemaType = "NOT_A_VALID_SCHEMA"
-    )
     val passedJobs: Seq[ErsSummary] = generateListOfErsSummaries(
-      numberRecords = 10,
-      schemaType = "passed"
+      numberRecords = 5,
+      transferStatus = Some("passed")
     )
 
-    failedJobs ++ failedJobsWithWrongSchema ++ passedJobs
+    failedJobs ++ passedJobs
   }
 
   def generatePresubmissionRecordsForMetadata(ersSummaries: Seq[ErsSummary]): Seq[SchemeData] = {
@@ -159,12 +158,12 @@ object Fixtures {
 
   val formatter: DateTimeFormatter = DateTimeFormat.forPattern("dd/MM/yyyy")
   val ersSummaries: Seq[JsObject] = Seq(
-    Fixtures.buildErsSummary(transferStatus = Some("passed"), schemaType = "CSOP"), // wrong status for resubmission
-    Fixtures.buildErsSummary(transferStatus = Some("successResubmit"), schemaType = "CSOP"), // wrong status for resubmission (already resubmitted)
-    Fixtures.buildErsSummary(transferStatus = Some("failed"), schemaType = "NOT_CSOP"), // wrong schema type for resubmission
-    Fixtures.buildErsSummary(transferStatus = Some("failed"), schemaType = "CSOP" , timestamp = DateTime.parse("30/04/2023", formatter)), // wrong date for resubmission
-    Fixtures.buildErsSummary(transferStatus = Some("failed"), schemaType = "CSOP", timestamp = DateTime.parse("10/05/2023", formatter)), // should resubmit
-    Fixtures.buildErsSummary(transferStatus = Some("failed"), schemaType = "CSOP", timestamp = DateTime.parse("20/05/2023", formatter)), // should resubmit
+    Fixtures.buildErsSummary(transferStatus = Some("passed"), schemaType = "CSOP", timestamp = DateTime.parse("30/04/2022", formatter)),
+    Fixtures.buildErsSummary(transferStatus = Some("successResubmit"), schemaType = "CSOP", timestamp = DateTime.parse("30/04/2021", formatter)),
+    Fixtures.buildErsSummary(transferStatus = Some("failed"), schemaType = "NOT_CSOP", timestamp = DateTime.parse("30/04/2000", formatter)),
+    Fixtures.buildErsSummary(transferStatus = Some("failed"), schemaType = "CSOP", timestamp = DateTime.parse("30/04/2023", formatter)),
+    Fixtures.buildErsSummary(transferStatus = Some("failed"), schemaType = "CSOP", timestamp = DateTime.parse("10/05/2023", formatter)),
+    Fixtures.buildErsSummary(transferStatus = Some("failed"), schemaType = "CSOP", timestamp = DateTime.parse("20/05/2023", formatter)),
   ).map(Json.toJsObject(_))
 
   val schemeData: Seq[JsObject] = Seq(

--- a/it/uk/gov/hmrc/resubmission/ResubJobNoFiltersEnabledSpec.scala
+++ b/it/uk/gov/hmrc/resubmission/ResubJobNoFiltersEnabledSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.resubmission
+
+import _root_.play.api.Application
+import _root_.play.api.inject.guice.GuiceApplicationBuilder
+import _root_.play.api.libs.json._
+import _root_.play.api.test.Helpers._
+import models.{ERSError, ErsSummary, SchemeData}
+import org.mongodb.scala.model.Filters
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import uk.gov.hmrc.{FakeErsStubService, Fixtures}
+
+class ResubJobNoFiltersEnabledSpec extends AnyWordSpecLike
+  with Matchers
+  with GuiceOneServerPerSuite
+  with FakeErsStubService {
+
+  val applicationConfig: Map[String, Any] = Map(
+    "microservice.services.ers-stub.port" -> "19339",
+    "schedules.resubmission-service.enabled" -> true,
+    "schedules.resubmission-service.dateTimeFilter.enabled" -> false,
+    "schedules.resubmission-service.schemaRefsFilter.enabled" -> false,
+    "schedules.resubmission-service.schemaFilter.enabled" -> false,
+    "schedules.resubmission-service.resubmissionLimit" -> 2,
+    "schedules.resubmission-service.resubmit-list-statuses" -> "failed",
+    "schedules.resubmission-service.resubmit-fail-status" -> "failedResubmission",
+    "schedules.resubmission-service.resubmit-successful-status" -> "successResubmit",
+    "auditing.enabled" -> false,
+    "settings.presubmission-collection-index-replace" -> false
+  )
+
+  override lazy val app: Application = new GuiceApplicationBuilder()
+    .configure(
+      conf = applicationConfig
+    )
+    .build()
+
+  "ResubPresubmissionServiceJob" should {
+    "resubmit failed jobs in batches with the correct transfer status and schema type" in new ResubmissionJobSetUp(app = app) {
+
+      val ersSummaries: Seq[ErsSummary] = Fixtures.generateListOfErsSummaries()
+      val schemeData: Seq[SchemeData] = Fixtures.generatePresubmissionRecordsForMetadata(ersSummaries)
+      val storeDocs: Boolean = await(storeMultipleErsSummary(ersSummaries.map(Json.toJsObject(_))))
+      val storePresubmissionDocs: Boolean = await(storeMultiplePresubmissionData(schemeData.map(Json.toJsObject(_))))
+      storeDocs shouldBe true
+      storePresubmissionDocs shouldBe true
+
+      countMetadataRecordsWithSelector(Filters.empty()) shouldBe 15
+      countMetadataRecordsWithSelector(successResubmitTransferStatusSelector) shouldBe 0
+      countMetadataRecordsWithSelector(failedJobSelector) shouldBe 10
+      val firstJobRunOutcome: Either[ERSError, Boolean] = await(getJob.scheduledMessage.service.invoke.value)
+      firstJobRunOutcome shouldBe Right(true)
+
+      countMetadataRecordsWithSelector(Filters.empty()) shouldBe 15
+      countMetadataRecordsWithSelector(successResubmitTransferStatusSelector) shouldBe 2
+      countMetadataRecordsWithSelector(failedJobSelector) shouldBe 8
+
+      val secondJobRunOutcome: Either[ERSError, Boolean] = await(getJob.scheduledMessage.service.invoke.value)
+      secondJobRunOutcome shouldBe Right(true)
+
+      countMetadataRecordsWithSelector(Filters.empty()) shouldBe 15
+      countMetadataRecordsWithSelector(successResubmitTransferStatusSelector) shouldBe 4
+      countMetadataRecordsWithSelector(failedJobSelector) shouldBe 6
+
+      val ersSummariesSecondStore = Fixtures.failedJobsWithDifferentBundleRef
+      val secondStoreDocs: Boolean = await(storeMultipleErsSummary(ersSummariesSecondStore.map(Json.toJsObject(_))))
+      secondStoreDocs shouldBe true
+
+      val presubmissionDocsSecondStore: Boolean = await(
+        storeMultiplePresubmissionData(Fixtures.generatePresubmissionRecordsForMetadata(ersSummariesSecondStore).map(Json.toJsObject(_))))
+      presubmissionDocsSecondStore shouldBe true
+
+      countMetadataRecordsWithSelector(Filters.empty()) shouldBe 25
+      countMetadataRecordsWithSelector(successResubmitTransferStatusSelector) shouldBe 4
+      countMetadataRecordsWithSelector(failedJobSelector) shouldBe 16
+      val thirdJobRunOutcome: Either[ERSError, Boolean] = await(getJob.scheduledMessage.service.invoke.value)
+      thirdJobRunOutcome shouldBe Right(true)
+
+      countMetadataRecordsWithSelector(Filters.empty()) shouldBe 25
+      countMetadataRecordsWithSelector(successResubmitTransferStatusSelector) shouldBe 6
+      countMetadataRecordsWithSelector(failedJobSelector) shouldBe 14
+    }
+  }
+}

--- a/it/uk/gov/hmrc/resubmission/ResubJobWithDateFilterEnabledSpec.scala
+++ b/it/uk/gov/hmrc/resubmission/ResubJobWithDateFilterEnabledSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc
+package uk.gov.hmrc.resubmission
 
 import _root_.play.api.Application
 import _root_.play.api.inject.guice.GuiceApplicationBuilder
@@ -24,6 +24,7 @@ import org.mongodb.scala.model.Filters
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import uk.gov.hmrc.{FakeErsStubService, Fixtures}
 
 class ResubJobWithDateFilterEnabledSpec extends AnyWordSpecLike
   with Matchers
@@ -32,13 +33,15 @@ class ResubJobWithDateFilterEnabledSpec extends AnyWordSpecLike
 
   val applicationConfig: Map[String, Any] = Map(
     "microservice.services.ers-stub.port" -> "19339",
+    "schedules.resubmission-service.enabled" -> true,
     "schedules.resubmission-service.dateTimeFilter.enabled" -> true,
     "schedules.resubmission-service.dateTimeFilter.filter" -> "1/5/2023",
     "schedules.resubmission-service.schemaRefsFilter.enabled" -> false,
-    "schedules.resubmission-service.schemaFilter.enabled" -> true,
+    "schedules.resubmission-service.schemaFilter.enabled" -> false,
     "schedules.resubmission-service.schemaFilter.filter" -> "CSOP",
     "schedules.resubmission-service.resubmissionLimit" -> 10,
     "schedules.resubmission-service.resubmit-list-statuses" -> "failed",
+    "schedules.resubmission-service.resubmit-fail-status" -> "failedResubmission",
     "schedules.resubmission-service.resubmit-successful-status" -> "successResubmit",
     "auditing.enabled" -> false
   )

--- a/it/uk/gov/hmrc/resubmission/ResubJobWithSchemaRefsFilterEnabledSpec.scala
+++ b/it/uk/gov/hmrc/resubmission/ResubJobWithSchemaRefsFilterEnabledSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.resubmission
+
+import _root_.play.api.Application
+import _root_.play.api.inject.guice.GuiceApplicationBuilder
+import _root_.play.api.libs.json._
+import _root_.play.api.test.Helpers._
+import models.{ERSError, ErsSummary, SchemeData}
+import org.joda.time.DateTime
+import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
+import org.mongodb.scala.model.Filters
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import uk.gov.hmrc.{CSOP, FakeErsStubService, Fixtures}
+
+import scala.collection.mutable.ListBuffer
+
+class ResubJobWithSchemaRefsFilterEnabledSpec extends AnyWordSpecLike
+  with Matchers
+  with GuiceOneServerPerSuite
+  with FakeErsStubService {
+
+  val applicationConfig: Map[String, Any] = Map(
+    "microservice.services.ers-stub.port" -> "19339",
+    "schedules.resubmission-service.enabled" -> true,
+    "schedules.resubmission-service.dateTimeFilter.enabled" -> false,
+    "schedules.resubmission-service.schemaRefsFilter.enabled" -> true,
+    "schedules.resubmission-service.schemaFilter.enabled" -> false,
+    "schedules.resubmission-service.schemaRefsFilter.filter" -> "123,789,101",
+    "schedules.resubmission-service.resubmissionLimit" -> 2,
+    "schedules.resubmission-service.resubmit-list-statuses" -> "failed",
+    "schedules.resubmission-service.resubmit-fail-status" -> "failedResubmission",
+    "schedules.resubmission-service.resubmit-successful-status" -> "successResubmit",
+    "auditing.enabled" -> false
+  )
+
+  val formatter: DateTimeFormatter = DateTimeFormat.forPattern("dd/MM/yyyy")
+
+  val submissionDatesAndSchemeRefs: Seq[(DateTime, String)] = Seq(
+    (DateTime.parse("11/04/2023", formatter), "123"),
+    (DateTime.parse("30/04/2023", formatter), "456"),
+    (DateTime.parse("10/05/2023", formatter), "789"),
+    (DateTime.parse("20/05/2023", formatter), "101"),
+    (DateTime.parse("16/05/2023", formatter), "121")
+  )
+
+  val ersSummaries: Seq[ErsSummary] = submissionDatesAndSchemeRefs.map {
+    case (submissionDate: DateTime, schemeRef: String) =>
+      Fixtures.buildErsSummary(transferStatus = Some("failed"), schemaType = "CSOP", timestamp = submissionDate, schemeRef = schemeRef)
+  } ++ Seq(
+    Fixtures.buildErsSummary(transferStatus = Some("passed"), schemaType = "CSOP"),
+    Fixtures.buildErsSummary(transferStatus = Some("successResubmit"), schemaType = "CSOP")
+  )
+
+  val presubmissionsData: Seq[SchemeData] = submissionDatesAndSchemeRefs.map {
+    case (submissionDate: DateTime, schemeRef: String) =>
+      SchemeData(
+        CSOP.schemeInfo.copy(timestamp = submissionDate, schemeRef = schemeRef),
+        "CSOP_OptionsRCL_V4",
+        None,
+        Some(ListBuffer(CSOP.buildOptionsRCL(withAllFields = true, "yes")))
+      )
+  }
+
+  override lazy val app: Application = new GuiceApplicationBuilder()
+    .configure(
+      conf = applicationConfig
+    )
+    .build()
+
+  "ResubPresubmissionServiceJob" should {
+    "resubmit failed jobs with the correct transfer status and in the scheme filter list" +
+      ", assigning successful jobs with the correct status" in new ResubmissionJobSetUp(app = app) {
+
+      val storeDocs: Boolean = await(storeMultipleErsSummary(ersSummaries.map(Json.toJsObject(_))))
+      val storePresubmissions: Boolean = await(storeMultiplePresubmissionData(presubmissionsData.map(Json.toJsObject(_))))
+      storeDocs shouldBe true
+      storePresubmissions shouldBe true
+
+      countMetadataRecordsWithSelector(Filters.empty()) shouldBe 7
+      countMetadataRecordsWithSelector(successResubmitTransferStatusSelector) shouldBe 1
+      countMetadataRecordsWithSelector(failedJobSelector) shouldBe 3
+
+      val firstUpdateCompleted: Either[ERSError, Boolean] = await(getJob.scheduledMessage.service.invoke.value)
+      firstUpdateCompleted shouldBe Right(true)
+
+      countMetadataRecordsWithSelector(Filters.empty()) shouldBe 7
+      countMetadataRecordsWithSelector(successResubmitTransferStatusSelector) shouldBe 3 // 2 resubmissions
+      countMetadataRecordsWithSelector(failedJobSelector) shouldBe 1
+
+      val secondUpdateCompleted: Either[ERSError, Boolean] = await(getJob.scheduledMessage.service.invoke.value)
+      secondUpdateCompleted shouldBe Right(true)
+
+      countMetadataRecordsWithSelector(Filters.empty()) shouldBe 7
+      countMetadataRecordsWithSelector(successResubmitTransferStatusSelector) shouldBe 4 // 1 resubmission
+      countMetadataRecordsWithSelector(failedJobSelector) shouldBe 0
+    }
+  }
+}

--- a/it/uk/gov/hmrc/resubmission/ResubmissionJobSetUp.scala
+++ b/it/uk/gov/hmrc/resubmission/ResubmissionJobSetUp.scala
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc
+package uk.gov.hmrc.resubmission
 
-import _root_.play.api.Application
-import _root_.play.api.libs.json.JsObject
-import _root_.play.api.test.Helpers._
 import org.mongodb.scala.MongoCollection
 import org.mongodb.scala.bson.BsonDocument
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.Filters
+import play.api.Application
+import play.api.libs.json.JsObject
 import repositories.{MetadataMongoRepository, PresubmissionMongoRepository}
 import scheduler.ResubmissionServiceImpl
 import services.resubmission.ProcessFailedSubmissionsConfig
 
 import scala.concurrent.{ExecutionContext, Future}
+import _root_.play.api.test.Helpers._
 
 case class ResubmissionJobSetUp(app: Application) {
 
@@ -66,5 +66,7 @@ case class ResubmissionJobSetUp(app: Application) {
 
   val failedJobSelector: BsonDocument = metadataMongoRepository.createFailedJobSelector(processFailedSubmissionsConfig)
 
-  val successResubmitTransferStatusSelector: Bson = Filters.eq("transferStatus", "successResubmit")
+  val successResubmitTransferStatusSelector: Bson = Filters.eq(
+    "transferStatus", app.configuration.get[String]("schedules.resubmission-service.resubmit-successful-status")
+  )
 }


### PR DESCRIPTION
# DDCE-4346
## Update application config:
- Remove `resubmission-service.statuses`
- Rename `resubmission-service.resubmit-list-failStatus` -> `resubmission-service.resubmit-fail-status`
## Update resubmission config:
- Resubmission failed status and search status now no longer depend on schemeRef filter parameter
- Resubmission failed status now pulled directly from config param `schedules.resubmission-service.resubmit-fail-status`
 - Resubmission search statuses now pulled directly from config param `schedules.resubmission-service.resubmit-list-statuses`
## Update integration tests:
- Split out integration tests to make each IT test a different filter