### PR TITLE
Ddce 5946

### DIFF
--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -63,23 +63,31 @@ class SubmissionService @Inject()(repositories: Repositories,
   def transformData(ersSummary: ErsSummary)(implicit request: Request[_], hc: HeaderCarrier): ERSEnvelope[JsObject] = {
     val startTime = System.currentTimeMillis()
 
-    adrSubmission.generateSubmission(ersSummary)(request, hc).map { json =>
-      val transformer = (__ \ "submitter" \ "firstName").json.update(__.read[JsString].map{ firstName =>
-        if (firstName.as[String].length > 35) {
-          logger.info(s"[SubmissionService][transformData] submitter name was greater than 35 characters for " +
+    val (maxFirstNameLen, maxCountryLen) = (35, 18)
+    
+    def trimDataIfSizeExceeded(json: JsObject, fieldName: String, maxLen: Int) = json.transform({
+      (__ \ "submitter" \ s"$fieldName").json.update(__.read[JsString].map { field =>
+        if (field.as[String].length > maxLen) {
+          logger.info(s"[SubmissionService][transformData] submitter $fieldName was greater than $maxLen characters for " +
             s"SchemeRef: ${ersSummary.metaData.schemeInfo.schemeRef}, trimming to allow submission")
-          JsString(firstName.as[String].take(35))
+          JsString(field.as[String].take(maxLen))
         } else {
-          firstName
+          field
         }
       })
+    }) match {
+      case JsSuccess(value, _) => value
+      case JsError(Seq((jsP, e))) =>
+        logger.error(jsP.path.mkString("") + " -> " + e.mkString(";") +" " + json.toString())
+        logger.info(s"[SubmissionService][transformData] Failed to transform $fieldName data, attempting to proceed untransformed")
+        json
+    }
+    
+    adrSubmission.generateSubmission(ersSummary)(request, hc).map { json =>
       metrics.generateJson(System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS)
-      json.transform(transformer) match {
-        case JsSuccess(value, _) => value
-        case JsError(_) =>
-          logger.info("[SubmissionService][transformData] Failed to transform data, attempting to proceed untransformed")
-          json
-      }
+      val transformedFirstNameJson = trimDataIfSizeExceeded(json, "firstName", maxFirstNameLen)
+      val transformedDataJson = trimDataIfSizeExceeded(transformedFirstNameJson, "country", maxCountryLen)
+      transformedDataJson
     }
   }
 

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -77,8 +77,7 @@ class SubmissionService @Inject()(repositories: Repositories,
       })
     }) match {
       case JsSuccess(value, _) => value
-      case JsError(Seq((jsP, e))) =>
-        logger.error(jsP.path.mkString("") + " -> " + e.mkString(";") +" " + json.toString())
+      case JsError(_) =>
         logger.info(s"[SubmissionService][transformData] Failed to transform $fieldName data, attempting to proceed untransformed")
         json
     }

--- a/test/helpers/ERSTestHelper.scala
+++ b/test/helpers/ERSTestHelper.scala
@@ -16,6 +16,7 @@
 
 package helpers
 
+import config.SchedulerModule
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.util.ByteString
 import org.scalatest.OptionValues
@@ -36,6 +37,7 @@ trait ERSTestHelper extends AnyWordSpecLike with Matchers with OptionValues with
 
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder()
+    .disable[SchedulerModule]
       .build()
 
   val mockCc: ControllerComponents = stubControllerComponents()


### PR DESCRIPTION
# DDCE-5946
The ERS submisision Json's  Country field extracted from the SchemeOrganiserDetails Country field which is needs to be trimmed to 18 characters otherwise it causes errors downstream. This was already done for the firstName field extracted from SchemeOrganiserDetails Company name field. 

A refactoring of the existing code was done to make a generic trimming method that both cases are now using. 

Tests were added for the json trimming, including a missing one for the trimming of the Company Name/First Name

A related PR on the same ticket is for ers-returns-frontend

 - [Y]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [Y]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [Y]  I've run a dependency check to ensure all dependencies are up to date
 - [Y]  I have included the JIRA issue number in the commit message
 - [N]  I've squashed my commits
