### PR TITLE
Add more logging for specified scheme refs

### DIFF
--- a/app/messages/AggregatedLogMessage.scala
+++ b/app/messages/AggregatedLogMessage.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package services.resubmission
+package messages
 
 import play.api.libs.json.{Format, Json}
 

--- a/app/messages/ResubmissionMessages.scala
+++ b/app/messages/ResubmissionMessages.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package models
+package messages
 
-import services.resubmission.AggregatedLog
+import models.ErsSummary
 import uk.gov.hmrc.mongo.lock.LockService
 
 trait ResubmissionMessages {
@@ -65,4 +65,23 @@ case class ResubmissionLimitMessage(resubmissionLimit: Long) extends Resubmissio
 case class AggregatedLogs(aggregatedLogs: Seq[AggregatedLog]) extends ResubmissionMessages {
   val message: String = s"$prefix Aggregated view of submissions: \n" +
     s"${aggregatedLogs.map(_.logLine).mkString("\n", "\n", "\n")}"
+}
+
+case class SelectedSchemeRefLogs(selectedErsSummary: Seq[ErsSummary]) extends ResubmissionMessages {
+  private def logLine(ersSummary: ErsSummary): String = s"schemaRef: ${ersSummary.metaData.schemeInfo.schemeRef}, " +
+    s"schemaType: ${ersSummary.metaData.schemeInfo.schemeType}, " +
+    s"taxYear: ${ersSummary.metaData.schemeInfo.taxYear}, " +
+    s"transferStatus: ${ersSummary.transferStatus.getOrElse("transfer status is not defined")}, " +
+    s"timestamp: ${ersSummary.metaData.schemeInfo.timestamp}"
+
+  val numberSelectedErsRecords: Int = selectedErsSummary.length
+  val message: String =
+    if (selectedErsSummary.isEmpty) {
+      s"$prefix Could not find any records for the selected scheme reference"
+    }
+    else if (numberSelectedErsRecords > 50){
+      s"$prefix Selected schemes have more then 50 records ($numberSelectedErsRecords records selected)"
+    } else {
+      s"$prefix Selected scheme details: ${selectedErsSummary.map(logLine).mkString("\n", "\n", "\n")}"
+    }
 }

--- a/app/repositories/Selectors.scala
+++ b/app/repositories/Selectors.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import org.mongodb.scala.bson.{BsonDocument, BsonString}
+
+import java.time.{LocalDate, ZoneId}
+import java.time.format.DateTimeFormatter
+import services.resubmission.ProcessFailedSubmissionsConfig
+import repositories.helpers.BsonDocumentHelper.BsonOps
+
+case class Selectors(processFailedSubmissionsConfig: ProcessFailedSubmissionsConfig) {
+  val baseSelector: BsonDocument = BsonDocument(
+    "transferStatus" -> BsonDocument(
+      "$in" -> processFailedSubmissionsConfig.searchStatusList.map(Some(_))
+    )
+  )
+
+  val schemeRefSelector: BsonDocument = BsonDocument(
+    processFailedSubmissionsConfig.schemeRefList.map(schemeList => "metaData.schemeInfo.schemeRef" -> BsonDocument("$in" -> schemeList))
+  )
+
+  val schemeSelector: BsonDocument = BsonDocument(
+    processFailedSubmissionsConfig.resubmitScheme.map(scheme => "metaData.schemeInfo.schemeType" -> BsonString(scheme))
+  )
+
+  val dateRangeSelector: BsonDocument = BsonDocument(processFailedSubmissionsConfig.dateTimeFilter.map(date =>
+    "metaData.schemeInfo.timestamp" -> BsonDocument("$gte" -> LocalDate.parse(date, DateTimeFormatter.ofPattern("dd/MM/yyyy")).atStartOfDay(ZoneId.of("UTC")).toInstant.toEpochMilli))
+  )
+
+  val allSelectors: BsonDocument = Seq(
+    baseSelector,
+    schemeRefSelector,
+    schemeSelector,
+    dateRangeSelector
+  ).foldLeft(BsonDocument())(_ +:+ _)
+}

--- a/app/services/resubmission/ReSubmissionSchedulerService.scala
+++ b/app/services/resubmission/ReSubmissionSchedulerService.scala
@@ -19,7 +19,7 @@ package services.resubmission
 import common.ERSEnvelope
 import common.ERSEnvelope.ERSEnvelope
 import config.ApplicationConfig
-import models._
+import messages._
 import play.api.libs.json.JsObject
 import play.api.mvc.Request
 import repositories.LockRepositoryProvider
@@ -68,6 +68,9 @@ class ReSubmissionSchedulerService @Inject()(val applicationConfig: ApplicationC
       resubPresubmissionService.logAggregateMetadataMetrics()
       resubPresubmissionService.logFailedSubmissionCount(processFailedSubmissionsConfig)
       logger.info(LockMessage(lockService).message)
+    }
+    logIfEnabled(applicationConfig.schedulerSchemeRefListEnabled) {
+      resubPresubmissionService.logSelectedSchemeRefDetails(processFailedSubmissionsConfig)
     }
 
     ERSEnvelope(lockService.withLock(resubmit()(request, hc).value).map {


### PR DESCRIPTION
Tested the new log message locally, the following are a few results:

With two different schemes:
```scala anotate
[ResubmissionService] Selected scheme details:
schemaRef: CSOP00000000124, schemaType: CSOP, taxYear: 2015/16, transferStatus: failedResubmission, timestamp: 2023-06-30T08:55:28.483Z
schemaRef: XE1100000000000, schemaType: EMI, taxYear: 2015/16, transferStatus: sent, timestamp: 2023-06-30T08:55:28.483Z
```

Multiple years for the same schemes:
```scala anotate
[ResubmissionService] Selected scheme details:
schemaRef: CSOP00000000124, schemaType: CSOP, taxYear: 2015/16, transferStatus: saved, timestamp: 2023-06-30T08:55:28.483Z
schemaRef: CSOP00000000124, schemaType: CSOP, taxYear: 2016/17, transferStatus: saved, timestamp: 2023-06-30T08:55:28.483Z
```

No schemes in DB:
```scala anotate
[ResubmissionService] Could not find any records for the selected scheme reference
```