### PR TITLE
DDCE-6057: Add created add to presubmission logs

### DIFF
--- a/app/messages/ResubmissionMessages.scala
+++ b/app/messages/ResubmissionMessages.scala
@@ -18,6 +18,7 @@ package messages
 
 import models.{ErsSummary, SchemeData}
 import uk.gov.hmrc.mongo.lock.LockService
+import java.time.LocalDateTime
 
 trait ResubmissionMessages {
   val prefix: String = "[ResubmissionService]"
@@ -86,12 +87,13 @@ case class MetaDataSelectedSchemeRefLogs(selectedErsSummary: Seq[ErsSummary]) ex
     }
 }
 
-case class PreSubSelectedSchemeRefLogs(selectedErsSummary: Seq[SchemeData]) extends ResubmissionMessages {
-  private def logLine(schemeData: SchemeData): String =
-    s"schemaRef: ${schemeData.schemeInfo.schemeRef}, " +
-    s"schemaType: ${schemeData.schemeInfo.schemeType}, " +
-    s"taxYear: ${schemeData.schemeInfo.taxYear}, " +
-    s"timestamp: ${schemeData.schemeInfo.timestamp}"
+case class PreSubSelectedSchemeRefLogs(selectedErsSummary: Seq[(SchemeData, LocalDateTime)]) extends ResubmissionMessages {
+  private def logLine(schemeDataWithCreatedAt: (SchemeData, LocalDateTime)): String =
+    s"schemaRef: ${schemeDataWithCreatedAt._1.schemeInfo.schemeRef}, " +
+      s"schemaType: ${schemeDataWithCreatedAt._1.schemeInfo.schemeType}, " +
+      s"taxYear: ${schemeDataWithCreatedAt._1.schemeInfo.taxYear}, " +
+      s"timestamp: ${schemeDataWithCreatedAt._1.schemeInfo.timestamp}, " +
+      s"createdAt: ${schemeDataWithCreatedAt._2}"
 
   val numberSelectedErsRecords: Int = selectedErsSummary.length
   val message: String =

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object AppDependencies {
   private val bootstrapVersion = "9.5.0"
   private val pekkoVersion = "1.0.2"
-  private val mongoVersion = "2.2.0"
+  private val mongoVersion = "2.3.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-30"    % bootstrapVersion,

--- a/test/services/resubmission/ResubPresubmissionServiceSpec.scala
+++ b/test/services/resubmission/ResubPresubmissionServiceSpec.scala
@@ -263,11 +263,12 @@ class ResubPresubmissionServiceSpec extends ERSTestHelper with BeforeAndAfterEac
       val taxYears: Seq[String] = Seq("2015/16", "2016/17", "2017/18", "2018/19", "2019/20", "2020/21", "2021/22")
       val schemeDataAsJsObject: Seq[JsObject] = taxYears
         .map(taxYear =>
-          Json.toJson(getSimpleSchemaData(schemeInfo.copy(taxYear = taxYear))).as[JsObject]
+          Json.toJson(getSimpleSchemaData(schemeInfo.copy(taxYear = taxYear))).as[JsObject] ++
+            Json.obj("createdAt" -> Json.obj("$date" -> Json.obj("$numberLong" -> "1420106400000")))
         )
 
       def createExpectedStringFromTaxYear(taxYear: String): String =
-        s"schemaRef: 123, schemaType: 123, taxYear: $taxYear, timestamp: 2023-10-07T10:15:30Z"
+        s"schemaRef: 123, schemaType: 123, taxYear: $taxYear, timestamp: 2023-10-07T10:15:30Z, createdAt: 2015-01-01T10:00"
 
       val expectedOutput = s"[ResubmissionService] PreSubSelectedSchemeRefLogs - Selected scheme details: " +
         s"${taxYears.map(createExpectedStringFromTaxYear).mkString("\n", "\n", "\n")}"
@@ -293,7 +294,10 @@ class ResubPresubmissionServiceSpec extends ERSTestHelper with BeforeAndAfterEac
 
     "produce a message indicating there are to many submissions to log out when getStatusForSelectedSchemes returns > 50 records" in {
       when(mockPresubmissionMongoRepository.getStatusForSelectedSchemes(anyString(), any()))
-        .thenReturn(ERSEnvelope(Seq.fill(51)(getSimpleSchemaData(schemeInfo)).map(Json.toJson(_).as[JsObject])))
+        .thenReturn(ERSEnvelope(Seq.fill(51)(
+          getSimpleSchemaData(schemeInfo)).map(Json.toJson(_).as[JsObject] ++
+          Json.obj("createdAt" -> Json.obj("$date" -> Json.obj("$numberLong" -> "1420106400000")))
+        )))
 
       val expectedOutput = s"[ResubmissionService] PreSubSelectedSchemeRefLogs - Selected schemes have more then 50 records (51 records selected)"
 


### PR DESCRIPTION
### Overview
- add `createdAt` field to selected presub scheme ref logs
- update unit tests

### Example of output locally
```
[ResubmissionService] PreSubSelectedSchemeRefLogs - Selected scheme details:
schemaRef: XD1100000000000, schemaType: CSOP, taxYear: 2014/15, timestamp: 2024-12-24T09:41:34.057Z, createdAt: 2024-12-24T09:44:14.046
```